### PR TITLE
Alteração no par chave/valor seprotreino.url

### DIFF
--- a/sample/treino/src/test/java/demoisellebehave/serpro/treino/config/Config.java
+++ b/sample/treino/src/test/java/demoisellebehave/serpro/treino/config/Config.java
@@ -3,6 +3,6 @@ package demoisellebehave.serpro.treino.config;
 
 public class Config {
 
-	public final static String URLBASE = "seprotreino.url";
+	public final static String URLBASE = "treino.url";
 	
 }

--- a/sample/treino/src/test/resources/behave.properties
+++ b/sample/treino/src/test/resources/behave.properties
@@ -1,4 +1,4 @@
-seprotreino.url=http://localhost:8080/treino
+treino.url=http://centro3.cta.serpro/treino
 
 behave.integration.alm.enabled=false
 


### PR DESCRIPTION
chave passou a ser treino.url e o valor http://centro3.cta.serpro/treino ao inves de localhost
