### PR TITLE
Implementação para locator com parâmetros usando a notação: %paramN%

### DIFF
--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/runner/ui/Element.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/runner/ui/Element.java
@@ -36,6 +36,8 @@
  */
 package br.gov.frameworkdemoiselle.behave.runner.ui;
 
+import java.util.List;
+
 import br.gov.frameworkdemoiselle.behave.annotation.ElementMap;
 
 /**
@@ -50,5 +52,7 @@ public interface Element {
 	public void setElementMap(ElementMap elementMap);
 	
 	public String getText();
+	
+	public void setLocatorParameters(List<String> Parameters);
 
 }

--- a/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/CommonSteps.java
+++ b/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/CommonSteps.java
@@ -36,6 +36,7 @@
  */
 package br.gov.frameworkdemoiselle.behave.parser.jbehave;
 
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -88,13 +89,21 @@ public class CommonSteps implements Step {
 		currentPageName = local;
 	}
 
+	@When("clico em \"$elementName\" referente a \"$locatorParameters\"")
+	@Then("clico em \"$elementName\" referente a \"$locatorParameters\"")
+	public void clickButtonWithParameters(String elementName, List<String> locatorParameters) {
+		Button element = (Button) runner.getElement(currentPageName, elementName);
+		element.setLocatorParameters(locatorParameters);
+		element.click();
+	}
+	
 	@When("clico em \"$elementName\"")
 	@Then("clico em \"$elementName\"")
 	public void clickButton(String elementName) {
 		Button element = (Button) runner.getElement(currentPageName, elementName);
 		element.click();
 	}
-
+	
 	@When("seleciono a opção \"$value\"")
 	@Then("seleciono a opção \"$value\"")
 	public void informe(String fieldName) {

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebBase.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebBase.java
@@ -27,12 +27,16 @@ import br.gov.frameworkdemoiselle.behave.runner.webdriver.util.Timer;
 
 public class WebBase extends MappedElement implements BaseUI {
 
+	private List<String> locatorParameters;
+	
 	public List<WebElement> getElements() {
 		List<WebElement> elements = new ArrayList<WebElement>();
 
 		for (String locator : getElementMap().locator()) {
-			By by = ByConverter.convert(getElementMap().locatorType(), locator);
 
+			locator = getLocatorWithParameters(locator);
+			By by = ByConverter.convert(getElementMap().locatorType(), locator);
+			
 			try {
 				// Utiliza implicity wait
 				WebElement element = getDriver().findElement(by);
@@ -43,6 +47,20 @@ public class WebBase extends MappedElement implements BaseUI {
 		}
 
 		return elements;
+	}
+
+	private String getLocatorWithParameters(String locator) {
+		
+		if( getLocatorParameter() != null && !getLocatorParameter().isEmpty() && locator.matches( ".*%param[0-9]+%.*" )) {
+			int n = 1;
+			for( String parameter : getLocatorParameter() ) {
+				String tag = "%param"+n+"%";
+				if( locator.contains( tag )) 
+					locator = locator.replace(tag, parameter);
+				n++;
+			}
+		}
+		return locator;
 	}
 
 	public String getText() {
@@ -104,8 +122,13 @@ public class WebBase extends MappedElement implements BaseUI {
 
 		verifyState(StateUI.ENABLE);
 		verifyState(StateUI.VISIBLE);
-		waitClickable(ByConverter.convert(getElementMap().locatorType(), getElementMap().locator()[index].toString()));
-		waitVisibility(ByConverter.convert(getElementMap().locatorType(), getElementMap().locator()[index].toString()));
+
+		String locator = getLocatorWithParameters( getElementMap().locator()[index].toString() );
+		By by = ByConverter.convert(getElementMap().locatorType(), locator);
+
+		waitClickable(by);
+		waitVisibility(by);
+		
 	}
 
 	/**
@@ -148,5 +171,14 @@ public class WebBase extends MappedElement implements BaseUI {
 		WebDriver driver = (WebDriver) getRunner().getDriver();
 		return driver;
 	}
+
+	public List<String> getLocatorParameter() {
+		return locatorParameters;
+	}
+
+	public void setLocatorParameters(List<String> locatorParameter2) {
+		this.locatorParameters = locatorParameter2;
+	}
+
 
 }


### PR DESCRIPTION
Implementação para locator com parâmetros:
Permite utilização de história como: Quando clico em "Alterar Obra" referente a "Arena Recife,pencil"
Neste caso, no locator as ocorrências de %param1% serão substituídas por "Arena Recife" (sem as aspas duplas) e as ocorrências de %param2% serão substituídas por "pencil" (sem as aspas duplas).

Esta implementação também permite o uso de uma lista de locators que use qualquer parâmetro, quantas vezes necessárias e em qualquer ordem. Por exemplo, pode-se definir uma lista de 2 locator usando o %param2% e %param1% como:
(...) locator = { "/tr[td=\"%param2%\"]", "/tr[td=\"%param1%\"]'" }
