### PR TITLE
Implementação de implementedBy para o fornecimento explicito de classe que implementa a interface Element no mapeamento de tela

### DIFF
--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/annotation/ElementMap.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/annotation/ElementMap.java
@@ -42,6 +42,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import br.gov.frameworkdemoiselle.behave.internal.spi.InjectionManager;
+
 /**
  * Anotação utilizada para mapear os campos com os atributos dentro de uma
  * página (Classe anotada com @Page).
@@ -58,5 +60,7 @@ public @interface ElementMap {
 	public ElementLocatorType locatorType() default ElementLocatorType.Id;
 
 	public String[] locator();
+	
+	public Class<?> implementedBy() default InjectionManager.class;
 
 }


### PR DESCRIPTION
Por padrão o framework irá utilizar o InjectionManager para encontrar a classe implementadora da interface, quando houver mais de uma classe, por padrão, o framework instancia a primeira que encontrar. Com esta implementação pode-se definir explicitamente uma implementação singular para uma interface dos elementos de tela, garantindo que a classe fornecida será usada para aquele elemento específico de tela, o que também permite a especialização de elementos de tela para tratar GUIs de frameworks web específicos.

Com esta implementação é possível a coexistência de diversas implementações de um elemento de tela, como por exemplo, um WebButton para um botão padrão html, um PrimeFacesButton ou um RichFacesButton para botões específicos, com códigos próprios tratando corretamente cada componente.

Este mecanismo também facilita o fornecimento de implementações alternativas pelo usuário sem exigir que o usuário conheça mecanismo do SPI. Desta forma a implementação do usuário será usada apenas explicitamente, nos demais casos a implementação padrão do framework será usada.
