### PR TITLE
Alteração que pemite a uma tela herdar elementos de outra tela extendendo sua classe.

### DIFF
--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/util/ReflectionUtil.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/util/ReflectionUtil.java
@@ -131,7 +131,7 @@ public class ReflectionUtil {
 		if (clazz == null)
 			throw new RuntimeException("Nenhuma Página foi encontrada com o nome [" + pageName + "].");
 
-		Set<Field> fields = ReflectionUtils.getFields(clazz, ReflectionUtils.withAnnotation(ElementMap.class));
+		Set<Field> fields = ReflectionUtils.getAllFields(clazz, ReflectionUtils.withAnnotation(ElementMap.class));
 
 		ElementMap map = null;
 


### PR DESCRIPTION
Em geral a tela dos sistemas possuem muitos elementos comuns entre-si e que podem ser reaproveitados.
Buscar o elemento em todos os campos da hierarquia de classes permite ao usuário criar uma estrutura de classes que imite a estrutura da composição da tela do sistema sendo testado, facilitando o mapeamento da tela para o usuário sem obrigá-lo a repetir elementos básicos e comuns a todas elas.
