### PR TITLE
Adição do métodos para selecionar uma opção na combobox pelo índice

### DIFF
--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/runner/ui/Select.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/runner/ui/Select.java
@@ -44,31 +44,30 @@ package br.gov.frameworkdemoiselle.behave.runner.ui;
 public interface Select extends BaseUI {
 
 	/**
-	 * Select all options that display text matching the argument. That is, when
-	 * given "Bar" this would select an option like: <option
-	 * value="foo">Bar</option> text.
+	 * Seleciona as opções que exibem o texto correspondente ao parâmetro. Ou
+	 * seja, passando "Bar" como parâmetro, selecionará a seguinte opção:
+	 * <option value="foo">Bar</option>
 	 * 
-	 * @param valueThe
-	 *            visible text to match against
+	 * @param value
+	 *            O texto visível na combo.
 	 */
 	public void selectByVisibleText(String value);
 
 	/**
-	 * Select the option at the given index. This is done by examing the "index"
-	 * attribute of an element, and not merely by counting.
+	 * Seleciona a opção no índice passado como argumento.
 	 * 
 	 * @param index
-	 *            The option at this index will be selected
+	 *            Índice da opção que será selecionada.
 	 */
 	public void selectByIndex(int index);
 
 	/**
-	 * Select all options that have a value matching the argument. That is, when
-	 * given "foo" this would select an option like: <option
-	 * value="foo">Bar</option>
+	 * Seleciona a opção que contém o valor correspondente ao parâmetro. Ou
+	 * seja, passando "foo" como parâmetro, selecionará a seguinte opção:
+	 * <option value="foo">Bar</option>
 	 * 
 	 * @param value
-	 *            The value to match against
+	 *            O valor da opção na combobox.
 	 */
 	public void selectByValue(String value);
 

--- a/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/CommonSteps.java
+++ b/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/CommonSteps.java
@@ -134,12 +134,23 @@ public class CommonSteps implements Step {
 		}
 	}
 
-	@When(value = "seleciono a opcao de indice \"$indice\" no campo \"$fieldName\"", priority = 10)
-	@Then(value = "seleciono a opcao de indice \"$indice\" no campo \"$fieldName\"", priority = 10)
-	public void selecionaIndice(String indice, String fieldName) {
+	@When(value = "seleciono a opção de índice \"$indice\" no campo \"$fieldName\"", priority = 10)
+	@Then(value = "seleciono a opção de índice \"$indice\" no campo \"$fieldName\"", priority = 10)
+	public void selectByIndex(String indice, String fieldName) {
 		Element element = runner.getElement(currentPageName, fieldName);
 		if (element instanceof Select) {
 			((Select) element).selectByIndex(Integer.valueOf(indice));
+		} else {
+			throw new BehaveException("Tipo de elemento [" + element.getClass().getName() + "] inválido");
+		}
+	}
+
+	@When(value = "seleciono a opção de valor \"$value\" no campo \"$fieldName\"", priority = 20)
+	@Then(value = "seleciono a opção de valor \"$value\" no campo \"$fieldName\"", priority = 20)
+	public void selectByValue(String value, String fieldName) {
+		Element element = runner.getElement(currentPageName, fieldName);
+		if (element instanceof Select) {
+			((Select) element).selectByValue(value);
 		} else {
 			throw new BehaveException("Tipo de elemento [" + element.getClass().getName() + "] inválido");
 		}

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebSelect.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebSelect.java
@@ -8,15 +8,13 @@ import org.openqa.selenium.WebElement;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.runner.ui.Select;
 
+/**
+ * @author SERPRO
+ */
 public class WebSelect extends WebBase implements Select {
 
 	/**
-	 * Select all options that display text matching the argument. That is, when
-	 * given "Bar" this would select an option like: <option
-	 * value="foo">Bar</option> text.
-	 * 
-	 * @param valueThe
-	 *            visible text to match against
+	 * {@inheritDoc}
 	 */
 	public void selectByVisibleText(String value) {
 		if (getElements().get(0).getTagName().equals("select")) {
@@ -46,11 +44,7 @@ public class WebSelect extends WebBase implements Select {
 	}
 
 	/**
-	 * Select the option at the given index. This is done by examing the "index"
-	 * attribute of an element, and not merely by counting.
-	 * 
-	 * @param index
-	 *            The option at this index will be selected
+	 * {@inheritDoc}
 	 */
 	public void selectByIndex(int index) {
 		if (getElements().get(0).getTagName().equals("select")) {
@@ -62,12 +56,7 @@ public class WebSelect extends WebBase implements Select {
 	}
 
 	/**
-	 * Select all options that have a value matching the argument. That is, when
-	 * given "foo" this would select an option like: <option
-	 * value="foo">Bar</option>
-	 * 
-	 * @param value
-	 *            The value to match against
+	 * {@inheritDoc}
 	 */
 	public void selectByValue(String value) {
 		if (getElements().get(0).getTagName().equals("select")) {


### PR DESCRIPTION
Adição do métodos para selecionar uma opção na combobox pelo índice ou pelo id, ao invés de apenas pelo texto:
public void selectByVisibleText(String value);
public void selectByIndex(int index);
public void selectByValue(String value);

---

Foi trocada a assinatura do método:
public void selectValue(String value);
por:
public void selectByVisibleText(String value);
Por ser o nome do método na classe do Select do Selenium.

Inclusive essa alteração foi pelo fato de o nome anterior, que era "selectValue", ser muito parecido com o Select do Selenium "selectByValue" que procura o valor da opção na combo e não o texto visivel.

Então, na minha opinão, ficaria mais claro usar o próprio nome do Selenium, que diz exatamente o que está buscando na combobox.

---

Também foi adicionado um CommonStep usando o selectByIndex(index).

Alberto Ivo Vieira.
