### PR TITLE
Adicionado driver para o Safari

### DIFF
--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/util/WebBrowser.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/util/WebBrowser.java
@@ -32,7 +32,9 @@ public enum WebBrowser {
 
 		@Override
 		public WebDriver getWebDriver() {
-			System.setProperty("webdriver.safari.noinstall", "true");
+			boolean driverConfigurado = !BehaveConfig.getRunner_ScreenDriverPath().isEmpty();
+			System.setProperty("webdriver.safari.noinstall", String.valueOf(driverConfigurado));
+			System.setProperty("webdriver.safari.driver", BehaveConfig.getRunner_ScreenDriverPath());
 			return new SafariDriver();
 		}
 	},


### PR DESCRIPTION
Adicionado driver para o Safari (funciona somente no Windows e Mac).

O navegador só funcionou normalmente com a passagem do arquivo contendo uma extensão (SafariDriver.safariextz) contido no pacote do selenium (/org/openqa/selenium/safari/SafariDriver.safariextz)
