### PR TITLE
Adicionado screenshot para web(webdriver) e desktop(fest-swing)

### DIFF
--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/config/BehaveConfig.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/config/BehaveConfig.java
@@ -214,6 +214,16 @@ public class BehaveConfig {
 	public static String getRunner_ScreenType() {
 		return getProperty("behave.runner.screen.type");
 	}
+	
+	// Ativa ou não "screenshot" na falha
+	public static boolean getRunner_ScreenshotEnabled() {
+		return Boolean.parseBoolean(getProperty("behave.runner.screenshot.enabled", "false"));
+	}
+	
+	// URL do screenshot
+	public static String getRunner_ScreenshotPath() {
+		return getProperty("behave.runner.screen.screenshotPath", System.getProperty("java.io.tmpdir"));
+	}
 
 	/*
 	 * Configurações especificas para testes Desktop

--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/controller/BehaveContext.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/controller/BehaveContext.java
@@ -36,6 +36,7 @@
  */
 package br.gov.frameworkdemoiselle.behave.controller;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,6 +49,7 @@ import br.gov.frameworkdemoiselle.behave.internal.parser.StoryFileConverter;
 import br.gov.frameworkdemoiselle.behave.internal.spi.InjectionManager;
 import br.gov.frameworkdemoiselle.behave.parser.Parser;
 import br.gov.frameworkdemoiselle.behave.parser.Step;
+import br.gov.frameworkdemoiselle.behave.runner.Runner;
 
 /**
  * 
@@ -157,5 +159,11 @@ public class BehaveContext {
 	public void fail(String step, Throwable fail) {
 		this.step = step;
 		this.fail = fail;
+		
+		if ( BehaveConfig.getRunner_ScreenshotEnabled() ) {
+			Runner runner = (Runner) InjectionManager.getInstance().getInstanceDependecy(Runner.class);
+			File screenshot = runner.getScreenshot();
+			log.info(" Screenshot = " + screenshot.getAbsolutePath());
+		}
 	}
 }

--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/runner/Runner.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/runner/Runner.java
@@ -36,6 +36,8 @@
  */
 package br.gov.frameworkdemoiselle.behave.runner;
 
+import java.io.File;
+
 import br.gov.frameworkdemoiselle.behave.runner.ui.Element;
 import br.gov.frameworkdemoiselle.behave.runner.ui.Screen;
 
@@ -67,5 +69,7 @@ public interface Runner {
 	public Object getDriver();
 	
 	public Screen getScreen();
+	
+	public File getScreenshot();
 
 }

--- a/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/FestRunner.java
+++ b/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/FestRunner.java
@@ -39,6 +39,7 @@ package br.gov.frameworkdemoiselle.behave.runner.fest;
 import java.awt.Container;
 import java.awt.Window;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.PrintStream;
 
 import javax.swing.JDialog;
@@ -52,6 +53,7 @@ import org.fest.swing.core.Robot;
 import org.fest.swing.edt.GuiActionRunner;
 import org.fest.swing.edt.GuiQuery;
 import org.fest.swing.fixture.FrameFixture;
+import org.fest.swing.image.ScreenshotTaker;
 
 import br.gov.frameworkdemoiselle.behave.annotation.ElementMap;
 import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
@@ -76,6 +78,7 @@ public class FestRunner implements Runner {
 	public FrameFixture mainFixture;
 	// public JComponentFixture currentFixture;
 	public String currentTitle;
+	private int countScreenshot;
 
 	@Override
 	public void start() {
@@ -243,6 +246,16 @@ public class FestRunner implements Runner {
 	@Override
 	public Screen getScreen() {
 		return null;
+	}
+	
+	public File getScreenshot() {
+		File screenshotFile = new File(BehaveConfig.getRunner_ScreenshotPath()+(++countScreenshot)+".png");
+		screenshotFile.getParentFile().mkdirs();
+		
+		ScreenshotTaker screenshotTaker = new ScreenshotTaker();
+		screenshotTaker.saveDesktopAsPng(screenshotFile.getAbsolutePath());
+		
+		return screenshotFile;
 	}
 
 }

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/WebDriverRunner.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/WebDriverRunner.java
@@ -36,10 +36,15 @@
  */
 package br.gov.frameworkdemoiselle.behave.runner.webdriver;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
+import org.openqa.selenium.OutputType;
 import org.openqa.selenium.Proxy;
+import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.UnsupportedCommandException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
@@ -60,6 +65,7 @@ public class WebDriverRunner implements Runner {
 	private Logger logger = Logger.getLogger(WebDriverRunner.class);
 	private WebDriver driver;
 	private WebBrowser browser;
+	private int countScreenshot;
 
 	void setWebDriver(WebDriver driver) {
 		this.driver = driver;
@@ -163,6 +169,20 @@ public class WebDriverRunner implements Runner {
 
 	public Screen getScreen() {
 		return (Screen) InjectionManager.getInstance().getInstanceDependecy(Screen.class);
+	}
+	
+	public File getScreenshot() {
+		File screenshotFile = new File(BehaveConfig.getRunner_ScreenshotPath()+(++countScreenshot)+".png");
+		screenshotFile.getParentFile().mkdirs();
+		
+		File screenshot = ((TakesScreenshot) driver).getScreenshotAs(OutputType.FILE);
+		try {
+			FileUtils.copyFile(screenshot, new File(screenshotFile.getAbsolutePath()));
+		} catch (IOException e) {
+			return null;
+		}
+		
+		return screenshotFile;
 	}
 
 }


### PR DESCRIPTION
Adicionado screenshot para web(webdriver) e desktop(fest-swing).

Por padrão, a funcionalidade está desativada.

Para ativar, setar a propriedade "behave.runner.screenshot.enabled" no "behave.properties"

Ex:
behave.runner.screenshot.enabled=true

Por padrão, o caminho padrão é o que estiver setada na propriedade da vm "java.io.tmpdir".

Para alterar, setar a propriedade "behave.runner.screen.screenshotPath" no "behave.properties"

Ex:
behave.runner.screen.screenshotPath=target/jbehave/images/
