### PR TITLE
Adiciona screenshot dos passos com erro no relatório padrão do jbehave

### DIFF
--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/runner/Runner.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/runner/Runner.java
@@ -71,5 +71,7 @@ public interface Runner {
 	public Screen getScreen();
 	
 	public File getScreenshot();
+	
+	public File saveScreenshotTo(String fileName);
 
 }

--- a/impl/parser/jbehave/pom.xml
+++ b/impl/parser/jbehave/pom.xml
@@ -74,6 +74,10 @@
 			<groupId>org.jbehave</groupId>
 			<artifactId>jbehave-core</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.jbehave.web</groupId>
+   			<artifactId>jbehave-web-selenium</artifactId>
+		</dependency>		
 	</dependencies>
 
 	<properties>

--- a/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/JBehaveParser.java
+++ b/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/JBehaveParser.java
@@ -72,6 +72,7 @@ import br.gov.frameworkdemoiselle.behave.parser.jbehave.converter.MapConverter;
 import br.gov.frameworkdemoiselle.behave.parser.jbehave.report.ALMStoryReport;
 import br.gov.frameworkdemoiselle.behave.parser.jbehave.report.DefaultStoryReport;
 import br.gov.frameworkdemoiselle.behave.parser.jbehave.report.console.ColoredConsoleFormat;
+import br.gov.frameworkdemoiselle.behave.parser.jbehave.report.html.ScreenShootingHtmlFormat;
 
 public class JBehaveParser extends ConfigurableEmbedder implements Parser {
 
@@ -167,7 +168,6 @@ public class JBehaveParser extends ConfigurableEmbedder implements Parser {
 	private Format[] getFormats() {
 
 		Format console = Format.CONSOLE;
-
 		// Verifica se existe uma variável de ambiente chamada COLORED_CONSOLE e
 		// ela possui valor diferente de zero.
 		// No console é necessário fazer: export COLORED_CONSOLE=1
@@ -175,8 +175,10 @@ public class JBehaveParser extends ConfigurableEmbedder implements Parser {
 		if (!StringUtils.isEmpty(ambiente) && !"0".equals(ambiente.toLowerCase())) {
 			console = new ColoredConsoleFormat();
 		}
+		
+		Format screenshootingFormat = new ScreenShootingHtmlFormat();
 
-		return new Format[] { console, Format.HTML, Format.STATS };
+		return new Format[] { console, screenshootingFormat, Format.STATS };
 	}
 
 }

--- a/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/report/html/ScreenShootingHtmlFormat.java
+++ b/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/report/html/ScreenShootingHtmlFormat.java
@@ -1,0 +1,22 @@
+package br.gov.frameworkdemoiselle.behave.parser.jbehave.report.html;
+
+import org.jbehave.core.reporters.FilePrintStreamFactory;
+import org.jbehave.core.reporters.Format;
+import org.jbehave.core.reporters.StoryReporter;
+import org.jbehave.core.reporters.StoryReporterBuilder;
+
+public class ScreenShootingHtmlFormat extends Format {
+
+	public ScreenShootingHtmlFormat() {
+		super("HTML");
+	}
+
+	@Override
+	public StoryReporter createStoryReporter(FilePrintStreamFactory factory, StoryReporterBuilder builder) {
+		factory.useConfiguration(builder.fileConfiguration("html"));
+
+		return new ScreenShootingHtmlOutput(factory.createPrintStream(), builder)
+				.doReportFailureTrace(builder.reportFailureTrace())
+				.doCompressFailureTrace(builder.compressFailureTrace());
+	}
+}

--- a/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/report/html/ScreenShootingHtmlOutput.java
+++ b/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/report/html/ScreenShootingHtmlOutput.java
@@ -1,0 +1,52 @@
+package br.gov.frameworkdemoiselle.behave.parser.jbehave.report.html;
+
+import java.io.PrintStream;
+
+import org.apache.log4j.Logger;
+import org.jbehave.core.failures.UUIDExceptionWrapper;
+import org.jbehave.core.model.Story;
+import org.jbehave.core.reporters.StoryReporterBuilder;
+import org.jbehave.web.selenium.WebDriverHtmlOutput;
+
+public class ScreenShootingHtmlOutput extends WebDriverHtmlOutput {
+	
+	private ScreenShootingMaker maker;
+	private static final Logger logger = Logger.getLogger(ScreenShootingHtmlOutput.class);
+
+	public ScreenShootingHtmlOutput(PrintStream output, StoryReporterBuilder reporterBuilder) {
+		super(output, reporterBuilder.keywords());
+		this.maker = new ScreenShootingMaker();
+		super.overwritePattern("failed",
+				"<div class=\"step failed\">{0} <span class=\"keyword failed\">({1})</span><br/><span class=\"message failed\">{2}</span>"
+						+ "<br/><img src=\"screenshots/failed-scenario-{3}.png\" alt=\"failing screenshot\"/></div>\n");
+	}
+
+	@Override
+	public void afterStory(boolean givenStory) {
+		super.afterStory(givenStory);
+		print("\n</body>\n</html>");
+	}
+
+	@Override
+	public void beforeStory(Story story, boolean givenStory) {
+		print("<html>\n<head>\n\t<style type=\"text/css\">@import \"view/style/jbehave-core.css\";</style>\n</head>\n\n<body>\n");
+		super.beforeStory(story, givenStory);
+	}
+
+	@Override
+	public void failed(String step, Throwable storyFailure) {
+		super.failed(step, storyFailure);
+		try {
+			
+			if(storyFailure instanceof UUIDExceptionWrapper) {			
+				UUIDExceptionWrapper uuidWrappedFailure = (UUIDExceptionWrapper) storyFailure;
+				this.maker.afterScenarioFailure(uuidWrappedFailure);
+			} else {
+				logger.warn("A tela de erro não foi salva.");
+			}
+
+		} catch (Exception ex) {
+			logger.warn("Falha ao capturar tela de erro.");
+		}
+	}
+}

--- a/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/report/html/ScreenShootingMaker.java
+++ b/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/report/html/ScreenShootingMaker.java
@@ -1,0 +1,68 @@
+package br.gov.frameworkdemoiselle.behave.parser.jbehave.report.html;
+
+import java.io.File;
+import java.text.MessageFormat;
+import java.util.UUID;
+
+import org.apache.log4j.Logger;
+import org.jbehave.core.failures.PendingStepFound;
+import org.jbehave.core.failures.UUIDExceptionWrapper;
+import org.jbehave.core.reporters.StoryReporterBuilder;
+
+import br.gov.frameworkdemoiselle.behave.internal.spi.InjectionManager;
+import br.gov.frameworkdemoiselle.behave.runner.Runner;
+
+public class ScreenShootingMaker {
+
+	private static final String DEFAULT_SCREENSHOT_PATH_PATTERN = "{0}/view/screenshots/failed-scenario-{1}.png";
+	private static final Logger logger = Logger.getLogger(ScreenShootingMaker.class);
+	
+	protected final StoryReporterBuilder reporterBuilder;
+	protected final String screenshotPathPattern;
+
+	public ScreenShootingMaker() {
+		this(new StoryReporterBuilder());
+	}
+
+	public ScreenShootingMaker(StoryReporterBuilder reporterBuilder) {
+		this(reporterBuilder, DEFAULT_SCREENSHOT_PATH_PATTERN);
+	}
+
+	public ScreenShootingMaker(StoryReporterBuilder reporterBuilder, String screenshotPathPattern) {
+		this.reporterBuilder = reporterBuilder;
+		this.screenshotPathPattern = screenshotPathPattern;
+	}
+
+	public void afterScenarioFailure(UUIDExceptionWrapper uuidWrappedFailure) throws Exception {
+		
+		Runner runner = (Runner) InjectionManager.getInstance().getInstanceDependecy(Runner.class);	
+		
+		// Não captura tela dos passos pendentes
+		if (uuidWrappedFailure instanceof PendingStepFound) {
+			return;
+		}
+		String screenshotPath = screenshotPath(uuidWrappedFailure.getUUID());
+
+		String currentUrl = "";
+		try {
+			currentUrl = runner.getCurrentUrl();
+		} catch (Exception e) {
+		}
+		
+		try {
+			runner.saveScreenshotTo(screenshotPath);
+		} catch (Exception ex) {			
+			logger.warn("Erro ao salvar screenshot da página '" + currentUrl + "'. Caminho: " + screenshotPath
+					+ ". Causa: " + ex.getMessage() + ".");
+			ex.printStackTrace();
+			return;			
+		}
+
+		logger.info("Screenshot da página '" + currentUrl + "' salvo em '" + screenshotPath + "' com "
+					+ new File(screenshotPath).length() + " bytes");
+	}
+
+	protected String screenshotPath(UUID uuid) {
+		return MessageFormat.format(screenshotPathPattern, reporterBuilder.outputDirectory(), uuid);
+	}
+}

--- a/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/FestRunner.java
+++ b/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/FestRunner.java
@@ -252,14 +252,15 @@ public class FestRunner implements Runner {
 	public File getScreenshot() {		
 		SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss-SSS");
 		String fileName = format.format(GregorianCalendar.getInstance().getTime());
-		File screenshotFile = new File(BehaveConfig.getRunner_ScreenshotPath()+(fileName)+".png");
-		
-		screenshotFile.getParentFile().mkdirs();
-		
+		return saveScreenshotTo(BehaveConfig.getRunner_ScreenshotPath()+(fileName)+".png");
+	}
+
+	public File saveScreenshotTo(String fileName) {		
+		File screenshotFile = new File(fileName);		
+		screenshotFile.getParentFile().mkdirs();						
 		ScreenshotTaker screenshotTaker = new ScreenshotTaker();
-		screenshotTaker.saveDesktopAsPng(screenshotFile.getAbsolutePath());
-		
-		return screenshotFile;
+		screenshotTaker.saveDesktopAsPng(screenshotFile.getAbsolutePath());	
+		return screenshotFile;		
 	}
 
 }

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/WebDriverRunner.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/WebDriverRunner.java
@@ -174,19 +174,22 @@ public class WebDriverRunner implements Runner {
 	
 	public File getScreenshot() {
 		SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss-SSS");
-		String fileName = format.format(GregorianCalendar.getInstance().getTime());
+		String fileName = format.format(GregorianCalendar.getInstance().getTime());	
+		return saveScreenshotTo(BehaveConfig.getRunner_ScreenshotPath()+fileName+".png");
+	}
+	
+	public File saveScreenshotTo(String fileName) {
 		
-		File screenshotFile = new File(BehaveConfig.getRunner_ScreenshotPath()+fileName+".png");
-		screenshotFile.getParentFile().mkdirs();
+		File screenshotFile = new File(fileName);
 		
+		screenshotFile.getParentFile().mkdirs();				
 		File screenshot = ((TakesScreenshot) driver).getScreenshotAs(OutputType.FILE);
 		try {
 			FileUtils.copyFile(screenshot, new File(screenshotFile.getAbsolutePath()));
 		} catch (IOException e) {
 			return null;
-		}
-		
-		return screenshotFile;
+		}		
+		return screenshotFile;		
 	}
 
 }

--- a/parent/behave/pom.xml
+++ b/parent/behave/pom.xml
@@ -191,6 +191,11 @@
 				<artifactId>jbehave-core</artifactId>
 				<version>3.8</version>
 			</dependency>
+			<dependency>
+				<groupId>org.jbehave.web</groupId>
+	   			<artifactId>jbehave-web-selenium</artifactId>
+	   			<version>3.5.4</version>
+			</dependency>			
 
 			<!-- runner -->
 			<dependency>


### PR DESCRIPTION
Foi criado um novo formato de relatório que estende do formato HTML padrão e insere os screenshots.
O screenshot é criado sempre que um step falha, independente de configuração. Ele é salvo dentro do diretório ./target/jbehave/view/screenshots
Para melhor visualização dos relatórios, recomenda-se adicionar o plugin abaixo no pom.xml do projeto.
Este plugin extrai os css e as imagens do relatório. 

<pre>
&lt;plugin&gt;
                &lt;groupId&gt;org.apache.maven.plugins&lt;/groupId&gt;
                &lt;artifactId&gt;maven-dependency-plugin&lt;/artifactId&gt; 
                &lt;executions&gt;
                    &lt;execution&gt; 
                        &lt;id&gt;unpack-jbehave-site-resources&lt;/id&gt;
                        &lt;phase&gt;generate-resources&lt;/phase&gt; 
                        &lt;goals&gt; 
                            &lt;goal&gt;unpack&lt;/goal&gt; 
                        &lt;/goals&gt; 
                        &lt;configuration&gt; 
                            &lt;overwriteReleases&gt;false&lt;/overwriteReleases&gt; 
                            &lt;overwriteSnapshots&gt;true&lt;/overwriteSnapshots&gt; 
                            &lt;artifactItems&gt; 
                                &lt;artifactItem&gt; 
                                    &lt;groupId&gt;org.jbehave.site&lt;/groupId&gt; 
                                    &lt;artifactId&gt;jbehave-site-resources&lt;/artifactId&gt; 
                                    &lt;version&gt;3.1.1&lt;/version&gt; 
                                    &lt;type&gt;zip&lt;/type&gt;
                                    &lt;outputDirectory&gt; ${project.build.directory}/jbehave/view&lt;/outputDirectory&gt; 
                                &lt;/artifactItem&gt; 
                            &lt;/artifactItems&gt; 
                        &lt;/configuration&gt; 
                    &lt;/execution&gt; 
                    &lt;execution&gt; 
                        &lt;id&gt;unpack-jbehave-reports-resources&lt;/id&gt;
                        &lt;phase&gt;generate-resources&lt;/phase&gt; 
                        &lt;goals&gt; 
                            &lt;goal&gt;unpack&lt;/goal&gt; 
                        &lt;/goals&gt; 
                        &lt;configuration&gt; 
                            &lt;overwriteReleases&gt;false&lt;/overwriteReleases&gt; 
                            &lt;overwriteSnapshots&gt;true&lt;/overwriteSnapshots&gt; 
                            &lt;artifactItems&gt; 
                                &lt;artifactItem&gt; 
                                    &lt;groupId&gt;org.jbehave&lt;/groupId&gt; 
                                    &lt;artifactId&gt;jbehave-core&lt;/artifactId&gt; 
                                    &lt;version&gt;${jbehave.core.version}&lt;/version&gt; 
                                    &lt;outputDirectory&gt;${project.build.directory}/jbehave/view&lt;/outputDirectory&gt; 
                                    &lt;includes&gt;**\/*.css,**\/*.ftl,**\/*.js&lt;/includes&gt; 
                                &lt;/artifactItem&gt; 
                            &lt;/artifactItems&gt; 
                        &lt;/configuration&gt; 
                    &lt;/execution&gt; 
                &lt;/executions&gt; 
            &lt;/plugin&gt;


Adicione também a dependencia

        &lt;dependency&gt;
            &lt;groupId&gt;org.jbehave&lt;/groupId&gt;
            &lt;artifactId&gt;jbehave-core&lt;/artifactId&gt;
            &lt;version&gt;3.6.7&lt;/version&gt;
        &lt;/dependency&gt; 
</pre>

O resultado final do relatório será este:
![relatorio](https://f.cloud.github.com/assets/888786/1034292/68f83606-0f14-11e3-85ba-a1a59f34b24d.png)
