### PR TITLE
Uso do profile para o Firefox

### DIFF
--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/config/BehaveConfig.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/config/BehaveConfig.java
@@ -209,9 +209,19 @@ public class BehaveConfig {
 		return getProperty("behave.runner.proxy.url");
 	}
 
-	// URL do proxy
+	// URL do driver
 	public static String getRunner_ScreenDriverPath() {
 		return getProperty("behave.runner.screen.driverPath");
+	}
+	
+	// Ativa o uso do profile do navegador
+	public static boolean getRunner_ProfileEnabled() {
+		return Boolean.parseBoolean(getProperty("behave.runner.profile.enabled", "false"));
+	}
+	
+	// URL do profile
+	public static String getRunner_ProfilePath() {
+		return getProperty("behave.runner.profile.url");
 	}
 
 	public static String getRunner_ScreenType() {

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/util/WebBrowser.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/util/WebBrowser.java
@@ -36,9 +36,12 @@
  */
 package br.gov.frameworkdemoiselle.behave.runner.webdriver.util;
 
+import java.io.File;
+
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.openqa.selenium.safari.SafariDriver;
@@ -54,6 +57,12 @@ public enum WebBrowser {
 
 		@Override
 		public WebDriver getWebDriver() {
+			if ( BehaveConfig.getRunner_ProfileEnabled() ) {
+				File profileDir = new File(BehaveConfig.getRunner_ProfilePath());
+	            FirefoxProfile profile = new FirefoxProfile(profileDir);
+	            return new FirefoxDriver(profile);
+			}
+			
 			return new FirefoxDriver();
 		}
 	},


### PR DESCRIPTION
Uso do profile para o Firefox.

Uso:
# Ativa o uso do profile

behave.runner.profile.enabled = true 
# Desativa o uso do profile

behave.runner.profile.enabled = false
# URL do profile para o navegador escolhido

behave.runner.profile.url = URL do profile para o navegador escolhido
