### PR TITLE
Permite especificar o display para o firefox em caso de rodar em ci

### DIFF
--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/config/BehaveConfig.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/config/BehaveConfig.java
@@ -228,6 +228,16 @@ public class BehaveConfig {
 		return getProperty("behave.runner.screen.type");
 	}
 	
+	// Ativa o uso de outro display utilizado pelo runner
+	public static boolean getRunner_DisplayEnabled() {
+		return Boolean.parseBoolean(getProperty("behave.runner.display.enabled", "false"));
+	}
+
+	// Indica o número do display utilizado pelo runner
+	public static String getRunner_DisplayNumber() {
+		return getProperty("behave.runner.display.number");
+	}	
+	
 	/*
 	 * Configurações especificas para testes Desktop
 	 */

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/util/WebBrowser.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/util/WebBrowser.java
@@ -40,6 +40,7 @@ import java.io.File;
 
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.firefox.FirefoxBinary;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
@@ -57,12 +58,28 @@ public enum WebBrowser {
 
 		@Override
 		public WebDriver getWebDriver() {
+			FirefoxProfile profile = null;
+
+			FirefoxBinary binary = null;
+
 			if ( BehaveConfig.getRunner_ProfileEnabled() ) {
 				File profileDir = new File(BehaveConfig.getRunner_ProfilePath());
-	            FirefoxProfile profile = new FirefoxProfile(profileDir);
-	            return new FirefoxDriver(profile);
+				
+				profile = new FirefoxProfile(profileDir);
 			}
-			
+
+			if ( BehaveConfig.getRunner_DisplayEnabled() ) {
+				binary = new FirefoxBinary();
+				
+				binary.setEnvironmentProperty("DISPLAY", ":" + BehaveConfig.getRunner_DisplayNumber());
+				
+				return new FirefoxDriver(binary, profile);
+			}
+
+			if ( profile != null ) {
+				return new FirefoxDriver(profile);
+			}
+
 			return new FirefoxDriver();
 		}
 	},


### PR DESCRIPTION
Permite especificar o display para o firefox em caso de rodar em ci.

Exemplo:

Estou em um servidor de ci e preciso passar  informação para o runner que ele abra o navegador no display x (no ci tem vários display com vários testes rodando em paralelo).

A depender do teste, o navegador vai abrir no display x ou y ou z.

Para ativar esta propriedade:

"behave.runner.display.enabled=true"
e
"behave.runner.display.number=x"
ou 
"behave.runner.display.number=y"
ou
"behave.runner.display.number=z"
