### PR TITLE
Incorporando a utilização de chaves nas ações de referência

### DIFF
--- a/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/CommonSteps.java
+++ b/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/CommonSteps.java
@@ -36,6 +36,7 @@
  */
 package br.gov.frameworkdemoiselle.behave.parser.jbehave;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -99,8 +100,16 @@ public class CommonSteps implements Step {
 	@When(value = "clico em \"$elementName\" referente a \"$locatorParameters\"", priority = 10)
 	@Then(value = "clico em \"$elementName\" referente a \"$locatorParameters\"", priority = 10)
 	public void clickButtonWithParameters(String elementName, List<String> locatorParameters) {
+		List<String> novosLocatorParameters = new ArrayList<String>();
+		
+		for (String locatorParameter : locatorParameters ) {
+			String novoLocatorParameter = dataProvider.containsKey(locatorParameter) ? (String) dataProvider.get(locatorParameter) : locatorParameter;
+			
+			novosLocatorParameters.add(novoLocatorParameter);
+		}
+		
 		Element element = runner.getElement(currentPageName, elementName);
-		element.setLocatorParameters(locatorParameters);
+		element.setLocatorParameters(novosLocatorParameters);
 
 		if (element instanceof Button) {
 			((Button) element).click();
@@ -136,8 +145,16 @@ public class CommonSteps implements Step {
 	@When(value = "seleciono a opção \"$elementName\" referente a \"$locatorParameters\"", priority = 10)
 	@Then(value = "seleciono a opção \"$elementName\" referente a \"$locatorParameters\"", priority = 10)
 	public void informeWithParameters(String elementName, List<String> locatorParameters) {
+		List<String> novosLocatorParameters = new ArrayList<String>();
+		
+		for (String locatorParameter : locatorParameters ) {
+			String novoLocatorParameter = dataProvider.containsKey(locatorParameter) ? (String) dataProvider.get(locatorParameter) : locatorParameter;
+			
+			novosLocatorParameters.add(novoLocatorParameter);
+		}
+		
 		Element element = runner.getElement(currentPageName, elementName);
-		element.setLocatorParameters(locatorParameters);
+		element.setLocatorParameters(novosLocatorParameters);
 
 		if (element instanceof Radio) {
 			((Radio) element).click();

--- a/sample/treino/src/test/java/demoisellebehave/serpro/treino/pages/ListaObrasPage.java
+++ b/sample/treino/src/test/java/demoisellebehave/serpro/treino/pages/ListaObrasPage.java
@@ -76,5 +76,8 @@ public class ListaObrasPage {
 	
 	@ElementMap(name = "Excluir Obra", locatorType = ElementLocatorType.XPath, locator = "(//tr[td/span/span='%param1%']//button)[1]")
 	private Button btExcluir;
+	
+	@ElementMap(name = "Excluir Nova Obra", locatorType = ElementLocatorType.XPath, locator = "(//tr[td[1]//.='%param1%'][td[2]//.='%param2%']//button)[1]")
+	private Button btExcluirNova;
 	 
 }

--- a/sample/treino/src/test/resources/stories/obras/adicionar-alterar-remover-obras.story
+++ b/sample/treino/src/test/resources/stories/obras/adicionar-alterar-remover-obras.story
@@ -46,7 +46,20 @@ Quando informo os campos: stories/obras/nova-obra.table
 Quando clico em "Inserir"
 Então será exibido "Nome da Obra"
 
+Quando informo:
+|obra|valor|prazo|
+|Nova Obra 4|55555.5|25/05/2013|
+
+Quando clico em "Adicionar Obra"
+Então será exibido "Cadastro"
+Quando informo "obra" no campo "Nome da Obra"
+Quando informo "valor" no campo "Valor"
+Quando informo "prazo" no campo "Prazo"
+Quando clico em "Inserir"
+Então será exibido "Nome da Obra"
+
 Sair do "Sistema"
+
 
 Cenário: Excluir Obra
 
@@ -58,5 +71,24 @@ Quando clico em "Excluir" referente a "Nova Obra"
 Então será exibido "Remover Obra: Nova Obra ?"
 Quando clico em "Sim"
 Então será exibido "Nova Obra. Registo removido."
+
+Sair do "Sistema"
+
+
+Cenário: Excluir Nova Obra 4 valor 55555.5
+
+Acesso ao Sistema com usuário "19296496063" e senha "205253"
+Dado que estou na tela "Tela Principal"
+Então vou para a tela "Lista de Obras"
+
+Quando informo "100" no campo "Registros por Página"
+
+Quando informo "obra" com valor "Nova Obra 4"
+Quando informo "valor" com valor "55555.5"
+Quando clico em "Excluir Nova Obra" referente a "obra, valor"
+
+Então será exibido "Remover Obra: Nova Obra 4 ?"
+Quando clico em "Sim"
+Então será exibido "Nova Obra 4. Registo removido."
 
 Sair do "Sistema"


### PR DESCRIPTION
Nas ações:
- clico em \"$elementName\" referente a \"$locatorParameters\"
- seleciono a opção \"$elementName\" referente a \"$locatorParameters\"

Não estava sendo permitido o uso de chaves do DataProvider (Ver exemplo na historia "stories/obras/adicionar-alterar-remover-obras.story").
