### PR TITLE
Permitir utilizar o minWait para diminuir a velocidade do robô

### DIFF
--- a/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopBase.java
+++ b/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopBase.java
@@ -57,6 +57,7 @@ import org.fest.swing.core.ComponentFinder;
 import org.fest.swing.core.ComponentMatcher;
 
 import br.gov.frameworkdemoiselle.behave.annotation.ElementLocatorType;
+import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.runner.fest.FestRunner;
 import br.gov.frameworkdemoiselle.behave.runner.fest.util.DesktopMappedElement;
@@ -68,6 +69,7 @@ public class DesktopBase extends DesktopMappedElement implements BaseUI {
 	protected FestRunner runner = (FestRunner) getRunner();
 
 	public Component getElement() {
+		waitThreadSleep(BehaveConfig.getRunner_ScreenMinWait());		
 
 		ComponentFinder cf = BasicComponentFinder.finderWithCurrentAwtHierarchy();
 


### PR DESCRIPTION
Permitir utilizar o "minWait" para diminuir a velocidade do robô.

Antes não estava sendo considerado o "minWait" mesmo colocando em "behave.properties".
