### PR TITLE
Inclusão de valores dos campos da tabela de exemplos nos passos dos  cenários de testes criados no alm

### DIFF
--- a/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/report/ALMStoryReport.java
+++ b/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/report/ALMStoryReport.java
@@ -39,6 +39,7 @@ package br.gov.frameworkdemoiselle.behave.parser.jbehave.report;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Hashtable;
+import java.util.Map;
 import java.util.TimeZone;
 
 import org.apache.log4j.Logger;
@@ -66,6 +67,8 @@ public class ALMStoryReport extends DefaultStoryReport {
 	Hashtable<String, Boolean> failedScenario = new Hashtable<String, Boolean>();
 	Hashtable<String, String> stepsScenario = new Hashtable<String, String>();
 	Hashtable<String, String> details = new Hashtable<String, String>();
+	
+	Map<String, String> examples;
 
 	protected Integration integration = (Integration) InjectionManager.getInstance().getInstanceDependecy(Integration.class);
 
@@ -120,7 +123,7 @@ public class ALMStoryReport extends DefaultStoryReport {
 
 	@Override
 	public void beforeStep(String step) {
-		String newString = stepsScenario.get(currentScenarioTitle) + "<br/>" + step;
+		String newString = stepsScenario.get(currentScenarioTitle) + "<br/>" + getNewStep(step);
 		stepsScenario.put(currentScenarioTitle, newString);
 	}
 
@@ -131,5 +134,23 @@ public class ALMStoryReport extends DefaultStoryReport {
 		details.put(currentScenarioTitle, message.getString("message-detail-result", step, detail.getMessage()));
 		failedScenario.put(currentScenarioTitle, true);
 		stepsScenario.put(currentScenarioTitle, message.getString("message-error-result", stepsScenario.get(currentScenarioTitle), cause.getCause()));
+	}
+
+	@Override
+	public void example(Map<String, String> tableRow) {
+		super.example(tableRow);
+		
+		examples = new Hashtable<String, String>();
+		examples.putAll(tableRow);
+	}
+	
+	private String getNewStep(String step) {
+		String newStep = step;
+		
+		for ( String key : examples.keySet() ) {
+			newStep = newStep.replaceAll("<"+key+">", examples.get(key));
+		}
+		
+		return newStep;
 	}
 }


### PR DESCRIPTION
Não estava sendo considerado os valores dos campos na tabela de exemplo quando o caso de testes era criado no alm. 

Estava assim:

Dado que vou para a tela "Tela de Login"
Quando informo "" no campo "Campo Usuário"
E informo "" no campo "Campo Senha"
Então será exibido na "Campo Senha" o valor ""
Quando clico em "Entrar"
Então será exibido "Obras"
Dado que estou na tela "Tela Principal"
Quando clico em "Sair"
Então será exibido "Usuário:"
E será exibido "Senha:"

Com a alteração, ficou assim:
Dado que vou para a tela "Tela de Login"
Quando informo "06762344887" no campo "Campo Usuário"
E informo "188542" no campo "Campo Senha"
Então será exibido na "Campo Senha" o valor "188542"
Quando clico em "Entrar"
Então será exibido "Obras"
Dado que estou na tela "Tela Principal"
Quando clico em "Sair"
Então será exibido "Usuário:"
E será exibido "Senha:"
