### PR TITLE
Permitir o uso de um firefox não padrão

### DIFF
--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/config/BehaveConfig.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/config/BehaveConfig.java
@@ -232,6 +232,11 @@ public class BehaveConfig {
 	public static String getRunner_ProfilePath() {
 		return getProperty("behave.runner.screen.profilePath");
 	}
+	
+	// Localização do binário do navegador
+	public static String getRunner_BinaryPath() {
+		return getProperty("behave.runner.screen.binaryPath", "");
+	}
 
 	public static String getRunner_ScreenType() {
 		return getProperty("behave.runner.screen.type");

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/util/WebBrowser.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/util/WebBrowser.java
@@ -43,6 +43,7 @@ import java.net.URL;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.firefox.FirefoxBinary;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
@@ -102,10 +103,20 @@ public enum WebBrowser {
 			if (BehaveConfig.getRunner_ProfileEnabled()) {
 				File profileDir = new File(BehaveConfig.getRunner_ProfilePath());
 				FirefoxProfile profile = new FirefoxProfile(profileDir);
+				if (!BehaveConfig.getRunner_BinaryPath().equals("")) {
+					File binaryDir = new File(BehaveConfig.getRunner_BinaryPath());
+					FirefoxBinary binary = new FirefoxBinary(binaryDir);
+					return new FirefoxDriver(binary, profile);
+				}
 				return new FirefoxDriver(profile);
 			}
 			FirefoxProfile profile = new FirefoxProfile();
 			profile.setEnableNativeEvents(true);
+			if (!BehaveConfig.getRunner_BinaryPath().equals("")) {
+				File binaryDir = new File(BehaveConfig.getRunner_BinaryPath());
+				FirefoxBinary binary = new FirefoxBinary(binaryDir);
+				return new FirefoxDriver(binary, profile);
+			}
 			return new FirefoxDriver(profile);
 		}
 	},

--- a/sample/treino/pom.xml
+++ b/sample/treino/pom.xml
@@ -44,7 +44,7 @@
 	<parent>
 		<groupId>br.gov.frameworkdemoiselle.component.behave</groupId>
 		<artifactId>demoiselle-behave-parent</artifactId>
-		<version>1.3.1-SNAPSHOT</version>
+		<version>1.3.2-SNAPSHOT</version>
 	</parent>
 
 	<name>Demoiselle Behave Treino</name>

--- a/sample/treino/src/test/resources/behave.properties
+++ b/sample/treino/src/test/resources/behave.properties
@@ -21,6 +21,17 @@ behave.integration.authenticator.host=127.0.0.1
 # ------------------- Navegador -------------------
 behave.runner.screen.maxWait=10000
 behave.runner.screen.type=MozillaFirefox
+
+
+#behave.runner.profile.enabled=false
+#behave.runner.screen.profilePath=C:\\Documents and Settings\\SERPRO\\Meus documentos\\profile
+#behave.runner.screen.profilePath=//home//Desktop//DB - Browsers//profile
+
+
+#behave.runner.screen.binaryPath=C:\\Documents and Settings\\SERPRO\\Meus documentos\\firefox.exe
+#behave.runner.screen.binaryPath=//home//Desktop//DB - Browsers//firefox-bin
+
+
 #behave.runner.screen.type=RemoteWeb
 #options: firefox, chrome, internetExplorer, safari, htmlUnit
 #behave.runner.screen.remote.name=firefox


### PR DESCRIPTION
Permitir o uso de um firefox não padrão, especificando o caminho do binário do navegador firefox. Ex:

Em "behave.properties" colocar/ativar a propriedade "behave.runner.screen.binaryPath" com o valor "/home/01069360503/firefox/firefox-bin"
