### PR TITLE
Alteração no DesktopBase para criação do Componente DesktopLink

### DIFF
--- a/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopBase.java
+++ b/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopBase.java
@@ -37,6 +37,7 @@
 package br.gov.frameworkdemoiselle.behave.runner.fest.ui;
 
 import java.awt.Component;
+import java.lang.reflect.Method;
 import java.util.Collection;
 
 import javax.swing.JButton;
@@ -110,7 +111,7 @@ public class DesktopBase extends DesktopMappedElement implements BaseUI {
 
 			if (button.getName() != null && getElementMap().locatorType() == ElementLocatorType.Name && button.getName().equalsIgnoreCase(getElementMap().locator()[0])) {
 				return true;
-			} else if (getElementMap().locatorType() == ElementLocatorType.Label && button.getText().equalsIgnoreCase(getElementMap().locator()[0])) {
+			} else if (button.getText() != null && getElementMap().locatorType() == ElementLocatorType.Label && button.getText().equalsIgnoreCase(getElementMap().locator()[0])) {
 				return true;
 			} else if (getElementMap().locatorType() == ElementLocatorType.ClassName && getElementMap().locator()[0].equals("JButton")) {
 				return true;
@@ -122,7 +123,7 @@ public class DesktopBase extends DesktopMappedElement implements BaseUI {
 
 			if (textField.getName() != null && getElementMap().locatorType() == ElementLocatorType.Name && textField.getName().equalsIgnoreCase(getElementMap().locator()[0])) {
 				return true;
-			} else if (getElementMap().locatorType() == ElementLocatorType.Label && textField.getText().equalsIgnoreCase(getElementMap().locator()[0])) {
+			} else if (textField.getText() != null && getElementMap().locatorType() == ElementLocatorType.Label && textField.getText().equalsIgnoreCase(getElementMap().locator()[0])) {
 				return true;
 			} else if (getElementMap().locatorType() == ElementLocatorType.ClassName && getElementMap().locator()[0].equals("JTextField")) {
 				return true;
@@ -156,7 +157,7 @@ public class DesktopBase extends DesktopMappedElement implements BaseUI {
 
 			if (menu.getName() != null && getElementMap().locatorType() == ElementLocatorType.Name && menu.getName().equalsIgnoreCase(getElementMap().locator()[0])) {
 				return true;
-			} else if (getElementMap().locatorType() == ElementLocatorType.Label && menu.getText().equalsIgnoreCase(getElementMap().locator()[0])) {
+			} else if (menu.getText() != null && getElementMap().locatorType() == ElementLocatorType.Label && menu.getText().equalsIgnoreCase(getElementMap().locator()[0])) {
 				return true;
 			} else if (getElementMap().locatorType() == ElementLocatorType.ClassName && getElementMap().locator()[0].equals("JMenu")) {
 				return true;
@@ -168,7 +169,7 @@ public class DesktopBase extends DesktopMappedElement implements BaseUI {
 
 			if (menuItem.getName() != null && getElementMap().locatorType() == ElementLocatorType.Name && menuItem.getName().equalsIgnoreCase(getElementMap().locator()[0])) {
 				return true;
-			} else if (getElementMap().locatorType() == ElementLocatorType.Label && menuItem.getText().equalsIgnoreCase(getElementMap().locator()[0])) {
+			} else if (menuItem.getText() != null && getElementMap().locatorType() == ElementLocatorType.Label && menuItem.getText().equalsIgnoreCase(getElementMap().locator()[0])) {
 				return true;
 			} else if (getElementMap().locatorType() == ElementLocatorType.ClassName && getElementMap().locator()[0].equals("JMenuItem")) {
 				return true;
@@ -180,7 +181,7 @@ public class DesktopBase extends DesktopMappedElement implements BaseUI {
 
 			if (checkBox.getName() != null && getElementMap().locatorType() == ElementLocatorType.Name && checkBox.getName().equalsIgnoreCase(getElementMap().locator()[0])) {
 				return true;
-			} else if (getElementMap().locatorType() == ElementLocatorType.Label && checkBox.getText().equalsIgnoreCase(getElementMap().locator()[0])) {
+			} else if (checkBox.getText() != null && getElementMap().locatorType() == ElementLocatorType.Label && checkBox.getText().equalsIgnoreCase(getElementMap().locator()[0])) {
 				return true;
 			} else if (getElementMap().locatorType() == ElementLocatorType.ClassName && getElementMap().locator()[0].equals("JCheckBox")) {
 				return true;
@@ -192,7 +193,7 @@ public class DesktopBase extends DesktopMappedElement implements BaseUI {
 
 			if (radio.getName() != null && getElementMap().locatorType() == ElementLocatorType.Name && radio.getName().equalsIgnoreCase(getElementMap().locator()[0])) {
 				return true;
-			} else if (getElementMap().locatorType() == ElementLocatorType.Label && radio.getText().equalsIgnoreCase(getElementMap().locator()[0])) {
+			} else if (radio.getText() != null && getElementMap().locatorType() == ElementLocatorType.Label && radio.getText().equalsIgnoreCase(getElementMap().locator()[0])) {
 				return true;
 			} else if (getElementMap().locatorType() == ElementLocatorType.ClassName && getElementMap().locator()[0].equals("JRadioButton")) {
 				return true;
@@ -214,7 +215,7 @@ public class DesktopBase extends DesktopMappedElement implements BaseUI {
 
 			for (int i = 0; i < tabbedPane.getComponentCount(); i++) {
 				// Busca no título, mas o locator esta como LABEL!
-				if (getElementMap().locatorType() == ElementLocatorType.Label && tabbedPane.getTitleAt(i).equalsIgnoreCase(getElementMap().locator()[0])) {
+				if (tabbedPane.getTitleAt(i) != null && getElementMap().locatorType() == ElementLocatorType.Label && tabbedPane.getTitleAt(i).equalsIgnoreCase(getElementMap().locator()[0])) {
 					return true;
 				} else if (getElementMap().locatorType() == ElementLocatorType.ClassName && getElementMap().locator()[0].equals("JTabbedPane")) {
 					return true;
@@ -227,6 +228,23 @@ public class DesktopBase extends DesktopMappedElement implements BaseUI {
 				return true;
 			}
 		}
+		
+		if ( getElementMap().locatorType() == ElementLocatorType.ClassName && component.getClass().getCanonicalName().equalsIgnoreCase(getElementMap().locator()[0]) ) {
+			if ( getElementMap().locator().length > 1 ) {
+				try {
+					Method getInformacaoMethod = component.getClass().getMethod("getText");
+					
+					String resultado = (String) getInformacaoMethod.invoke(component);
+					
+					return resultado.equalsIgnoreCase(getElementMap().locator()[1]);
+				} catch (Exception e) {
+					return false;
+				}
+			} else {
+				return true;
+			}
+		}
+		
 		return false;
 	}
 

--- a/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopLink.java
+++ b/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopLink.java
@@ -1,0 +1,12 @@
+package br.gov.frameworkdemoiselle.behave.runner.fest.ui;
+
+import br.gov.frameworkdemoiselle.behave.runner.ui.Link;
+
+public class DesktopLink extends DesktopBase implements Link {
+
+	@Override
+	public void click() {
+		runner.robot.click(getElement());
+	}
+
+}

--- a/impl/runner/fest/src/main/resources/META-INF/services/br.gov.frameworkdemoiselle.behave.runner.ui.Link
+++ b/impl/runner/fest/src/main/resources/META-INF/services/br.gov.frameworkdemoiselle.behave.runner.ui.Link
@@ -1,0 +1,1 @@
+br.gov.frameworkdemoiselle.behave.runner.fest.ui.DesktopLink

--- a/sample/treino-desktop/pom.xml
+++ b/sample/treino-desktop/pom.xml
@@ -45,7 +45,7 @@
 	<parent>
 		<groupId>br.gov.frameworkdemoiselle.component.behave</groupId>
 		<artifactId>demoiselle-behave-parent</artifactId>
-		<version>1.3.1-SNAPSHOT</version>
+		<version>1.3.2-SNAPSHOT</version>
 	</parent>
 
 	<name>Demoiselle Behave Treino Desktop</name>


### PR DESCRIPTION
Alteração no DesktopBase para criação do Componente DesktopLink (componente "Component" que não herde de "JButton" que é clicável na aplicação). Foi preciso alterar a busca de componentes em DesktopBase para permitir busca pelo nome completo da classe do objeto na hierarquia. Também é possível usar a combinação com o texto que está sendo exibido no componente "Component".

Ex:

@ElementMap(name = "Novo", locatorType = ElementLocatorType.ClassName, locator = {"br.gov.serpro.gcap.gui.componente.JTaskAction", "Novo"})
    private Link toolBarNovoDemonstrativo;

com possibilidade de usar também o ElementIndex

@ElementMap(name = "Novo", locatorType = ElementLocatorType.ClassName, locator = "br.gov.serpro.gcap.gui.componente.JTaskAction")
@ElementIndex(index=0)
    private Link toolBarNovoDemonstrativo;
