### PR TITLE
Implementação de componente para o rich:fileupload

### DIFF
--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebBase.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebBase.java
@@ -148,7 +148,7 @@ public class WebBase extends MappedElement implements BaseUI {
 		return getElements().get(0).getText();
 	}
 
-	private static void waitThreadSleep(Long delay) {
+	protected static void waitThreadSleep(Long delay) {
 		try {
 			Thread.sleep(delay);
 		} catch (InterruptedException ex) {

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/richfaces4/RichFileUpload.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/richfaces4/RichFileUpload.java
@@ -1,0 +1,148 @@
+/*
+ * Demoiselle Framework
+ * Copyright (C) 2013 SERPRO
+ * ----------------------------------------------------------------------------
+ * This file is part of Demoiselle Framework.
+ * 
+ * Demoiselle Framework is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License version 3
+ * as published by the Free Software Foundation.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this program; if not,  see <http://www.gnu.org/licenses/>
+ * or write to the Free Software Foundation, Inc., 51 Franklin Street,
+ * Fifth Floor, Boston, MA  02110-1301, USA.
+ * ----------------------------------------------------------------------------
+ * Este arquivo é parte do Framework Demoiselle.
+ * 
+ * O Framework Demoiselle é um software livre; você pode redistribuí-lo e/ou
+ * modificá-lo dentro dos termos da GNU LGPL versão 3 como publicada pela Fundação
+ * do Software Livre (FSF).
+ * 
+ * Este programa é distribuído na esperança que possa ser útil, mas SEM NENHUMA
+ * GARANTIA; sem uma garantia implícita de ADEQUAÇÃO a qualquer MERCADO ou
+ * APLICAÇÃO EM PARTICULAR. Veja a Licença Pública Geral GNU/LGPL em português
+ * para maiores detalhes.
+ * 
+ * Você deve ter recebido uma cópia da GNU LGPL versão 3, sob o título
+ * "LICENCA.txt", junto com esse programa. Se não, acesse <http://www.gnu.org/licenses/>
+ * ou escreva para a Fundação do Software Livre (FSF) Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA 02111-1301, USA.
+ */
+package br.gov.frameworkdemoiselle.behave.runner.webdriver.ui.richfaces4;
+
+import org.openqa.selenium.WebElement;
+
+import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
+import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.runner.webdriver.WebDriverRunner;
+import br.gov.frameworkdemoiselle.behave.runner.webdriver.ui.WebBase;
+
+/**
+ * Componente para mapear elementos de tela referentes ao componente rich:fileupload
+ * 
+ * Utiliza a API Javascript do Richfaces para a correta manipulação do componente.
+ * O locator do mapeamento de tela deve retornar o primeiro div gerado pelo componente rich:fileupload,
+ * aquele div que possui 'class="rf-cal"' ou ainda que possui o mesmo ID informado no arquivo XHTML,
+ * porém, o ID não é obrigatório, basta selecionar o primeiro div gerado pelo componente.
+ * 
+ * @author lmveloso
+ *
+ */
+public class RichFileUpload extends WebBase {
+
+	private static BehaveMessage message = new BehaveMessage(WebDriverRunner.MESSAGEBUNDLE);
+	
+	public void sendKeys(CharSequence... keysToSend) {
+		checkRichfacesComponent();
+		String jsCodeGetInput = "return (function(id){ return RichFaces.$(id).input[0]; })('"+getId()+"');";
+		WebElement input = (WebElement) getJavascirptExecutor().executeScript(jsCodeGetInput);
+		input.sendKeys(keysToSend);
+	}
+
+	
+	public void setValue(String value) {
+		sendKeys(value);
+	}
+
+	public void add(String pathToFile){
+		if(!canAdd())
+			throw new BehaveException(message.getString("exception-error-click", "Add", this.getElementMap().name()));
+		sendKeys(pathToFile);
+	}
+	public boolean canAdd() {
+		checkRichfacesComponent();
+		String jsCode = "return (function(id) { var rf = RichFaces.$(id); return (rf.addButton.prop('style').display != \"none\");})('"+getId()+"');";
+		return (Boolean) getJavascirptExecutor().executeScript(jsCode);
+	}
+	
+	public void clearAll(){
+		checkRichfacesComponent();
+		getJavascirptExecutor().executeScript("RichFaces.$('"+getId()+"').clearButton.click();");
+		
+	}
+
+	public void upload(){
+		checkRichfacesComponent();
+		getJavascirptExecutor().executeScript("RichFaces.$('"+getId()+"').uploadButton.click();");
+	}
+	
+	public String getSubmitedItemState(String label) {
+		checkRichfacesComponent();
+		String jsCode = "return (function(id,label) { var rf = RichFaces.$(id); var l = rf.list.find('.rf-fu-itm:contains('+label+') .rf-fu-itm-st'); if( rf.list.find('.rf-fu-itm:contains('+label+') .rf-pb').length == 0 && l.length == 1 ) return l.text(); return null;  })('"+getId()+"', '"+label+"' );";
+		return (String) getJavascirptExecutor().executeScript(jsCode);
+	}
+
+	public Boolean waitUntilSubmitItAll() {
+		checkRichfacesComponent();
+
+		// Condições verificadas: não haver nenhuma progress bar; não haver nenhum item pendente de envio; haver algum item na lista de itens enviados
+		String jsCodeAllSent = "return (function(id) { var rf = RichFaces.$(id); return (rf.list.find('.rf-pb').length == 0 && rf.items.length == 0 && rf.submitedItems.length > 0); })('"+getId()+"' );";
+		Boolean allSent = (Boolean) getJavascirptExecutor().executeScript(jsCodeAllSent);
+		
+		if(! allSent ) {
+			// Verifica se há alguma progress bar, indicando o progresso do envio de arquivo
+			String jsCodeIsUploading = "return (function(id) { var rf = RichFaces.$(id); return rf.list.find('.rf-pb').length != 0; })('"+getId()+"' );";
+			Boolean isSending = (Boolean) getJavascirptExecutor().executeScript(jsCodeIsUploading);
+			int waitTime = 0;
+			while( isSending && waitTime < BehaveConfig.getRunner_ScreenMaxWait() ) {
+				// aguarda o termino do envio
+				waitThreadSleep(BehaveConfig.getRunner_ScreenMinWait());
+				waitTime += BehaveConfig.getRunner_ScreenMinWait();
+				isSending = (Boolean) getJavascirptExecutor().executeScript(jsCodeIsUploading);
+			}
+			if( isSending )
+				return false; // timeout
+			// Verifica se todos os itens foram enviados 
+			return (Boolean) getJavascirptExecutor().executeScript(jsCodeAllSent);
+		}
+		
+		String jsCodeIsUploading = "return (function(id) { var rf = RichFaces.$(id); return (rf.list.find('.rf-pb').length == 0 && rf.items.length == 0 && rf.submitedItems.length > 0); })('"+getId()+"' );";
+		return (Boolean) getJavascirptExecutor().executeScript(jsCodeIsUploading);
+	}
+	
+	/**
+	 * Verifica se o componente selecionado é realmente um coponente rich:fileupload
+	 * @return
+	 */
+	public boolean isRichFileUpload(){
+		String jsCodeCheckComponent = "return (function(tipo, id) { var rf = RichFaces.$(id); return (typeof(rf) == \"object\" && typeof(rf.name) == \"string\" && rf.name == tipo);})('FileUpload','"+getId()+"');";
+		return (Boolean) getJavascirptExecutor().executeScript(jsCodeCheckComponent);
+	}
+	
+	/**
+	 * Método para garantir que o componente correto foi selecionado
+	 */
+	private void checkRichfacesComponent() {
+		if (!isRichFileUpload()) {
+			throw new BehaveException(message.getString("exception-not-rich-type", this.getElementMap().name(), getId(), "rich:fileupload"));
+		}
+
+	}
+}

--- a/sample/mix/pom.xml
+++ b/sample/mix/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>br.gov.frameworkdemoiselle.component.behave</groupId>
 		<artifactId>demoiselle-behave-parent</artifactId>
-		<version>1.3.1-SNAPSHOT</version>
+		<version>1.3.2-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/sample/mix/src/test/java/demoisellebehave/mix/pages/ShowcaseFileUpload.java
+++ b/sample/mix/src/test/java/demoisellebehave/mix/pages/ShowcaseFileUpload.java
@@ -1,0 +1,15 @@
+package demoisellebehave.mix.pages;
+
+import br.gov.frameworkdemoiselle.behave.annotation.ElementLocatorType;
+import br.gov.frameworkdemoiselle.behave.annotation.ElementMap;
+import br.gov.frameworkdemoiselle.behave.annotation.ScreenMap;
+import br.gov.frameworkdemoiselle.behave.runner.webdriver.ui.richfaces4.RichFileUpload;
+
+@ScreenMap(name = "Showcase FileUpload", 
+	location = "http://showcase.richfaces.org/richfaces/component-sample.jsf?demo=fileUpload&skin=blueSky")
+public class ShowcaseFileUpload {
+
+	@ElementMap(name = "FileUpload", locatorType = ElementLocatorType.Id, locator = "j_idt1272:upload")
+	private RichFileUpload richFileUpload;
+
+}

--- a/sample/mix/src/test/java/demoisellebehave/mix/steps/MySteps.java
+++ b/sample/mix/src/test/java/demoisellebehave/mix/steps/MySteps.java
@@ -5,12 +5,14 @@ import java.util.List;
 import junit.framework.Assert;
 
 import org.jbehave.core.annotations.Then;
+import org.jbehave.core.annotations.When;
 import org.openqa.selenium.WebElement;
 
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.parser.jbehave.CommonSteps;
 import br.gov.frameworkdemoiselle.behave.runner.webdriver.ui.WebButton;
 import br.gov.frameworkdemoiselle.behave.runner.webdriver.ui.primefaces.Tree;
+import br.gov.frameworkdemoiselle.behave.runner.webdriver.ui.richfaces4.RichFileUpload;
 
 public class MySteps extends CommonSteps {
 	
@@ -87,5 +89,30 @@ public class MySteps extends CommonSteps {
 		}
 	}
 
+	@When("informo no \"$element\" o arquivo \"$arquivo\"")
+	public void adicionarArquivo(String element, String arquivo){
+		RichFileUpload fu = (RichFileUpload)runner.getElement(currentPageName, element);
+		fu.add(arquivo);
+	}
 
+	@When("aciono \"$funcionalidade\" no campo \"$element\"")
+	public void acionarFuncionalidade(String funcionalidade, String element){
+		RichFileUpload fu = (RichFileUpload)runner.getElement(currentPageName, element);
+		if( "Upload".equals(funcionalidade)) {
+			fu.upload();
+			fu.waitUntilSubmitItAll();
+		}
+		else if( "Clear All".equals(funcionalidade))
+			fu.clearAll();
+	}
+
+	@Then("no \"$element\" o estado do arquivo \"$item\" ser\u00E1 \"$estado\"")
+	public void thenEstadoDoItemSera(String element, String item, String estado) {
+		RichFileUpload fu = (RichFileUpload)runner.getElement(currentPageName, element);
+		String state = fu.getSubmitedItemState( item );
+		Assert.assertNotNull(state);
+		Assert.assertEquals(state, estado);
+	}	
+	
+	
 }

--- a/sample/mix/src/test/java/demoisellebehave/mix/tests/TestRichFileUpload.java
+++ b/sample/mix/src/test/java/demoisellebehave/mix/tests/TestRichFileUpload.java
@@ -1,0 +1,23 @@
+package demoisellebehave.mix.tests;
+
+import org.junit.Test;
+
+import demoisellebehave.mix.steps.MySteps;
+
+import br.gov.frameworkdemoiselle.behave.controller.BehaveContext;
+
+public class TestRichFileUpload {
+
+	private BehaveContext eng = null;
+
+	public TestRichFileUpload() {
+		eng = BehaveContext.getInstance();
+		eng.addSteps(new MySteps());
+	}
+
+	@Test
+	public void testAllStories() throws Throwable {
+		eng.run("/stories/richfaces4/fileupload.story");
+	}
+
+}

--- a/sample/mix/src/test/resources/stories/richfaces4/fileupload.story
+++ b/sample/mix/src/test/resources/stories/richfaces4/fileupload.story
@@ -1,0 +1,14 @@
+Funcionalidade: Usar Componente FileUpload
+
+!--Como um: visitante
+Eu quero: usar o componente FileUpload
+De modo que: o arquivo seja adicionado e enviado para o servidor
+
+Cenário: Adicionar arquivo
+Dado que vou para a tela "Showcase FileUpload"
+Quando informo no "FileUpload" o arquivo "/tmp/logo1.png"
+Quando informo no "FileUpload" o arquivo "/tmp/IMG_0417.JPG"
+Quando aciono "Upload" no campo "FileUpload"
+Então no "FileUpload" o estado do arquivo "logo1.png" será "Done"
+Então no "FileUpload" o estado do arquivo "IMG_0417.JPG" será "File size is exceeded"  
+Quando aciono "Clear All" no campo "FileUpload"


### PR DESCRIPTION
Mapeia os botões de funcionalidade 'Add', 'Upload' e 'Clear All'.
Aguarda o Upload de todos os arquivos respeitando o timeout definido no behave.runner.screen.maxWait.
Permite verificar o status do upload de cada arquivo fornecendo o nome do arquivo e o texto do status esperado para aquele arquivo.
