### PR TITLE
Permitir o uso da janela do navegador em modo maximizado

### DIFF
--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/config/BehaveConfig.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/config/BehaveConfig.java
@@ -245,6 +245,11 @@ public class BehaveConfig {
 	public static String getRunner_CatchUIException() {
 		return getProperty("behave.runner.catchUIException");
 	}
+	
+	// Ativa o uso maximizada da janela do navegador
+	public static boolean getRunner_WindowMaximizeEnabled() {
+		return Boolean.parseBoolean(getProperty("behave.runner.window.maximize.enabled", "false"));
+	}
 
 	/*
 	 * Configurações especificas para testes Desktop

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/WebDriverRunner.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/WebDriverRunner.java
@@ -81,6 +81,9 @@ public class WebDriverRunner implements Runner {
 		if (driver == null) {
 			browser = Enum.valueOf(WebBrowser.class, BehaveConfig.getRunner_ScreenType());
 			driver = browser.getWebDriver();
+			if ( BehaveConfig.getRunner_WindowMaximizeEnabled() ) {
+				driver.manage().window().maximize();
+			}
 			logger.debug(message.getString("message-webdriver-started", browser.toString()));
 			try {
 				driver.manage().timeouts().pageLoadTimeout(BehaveConfig.getRunner_ScreenMaxWait(), TimeUnit.MILLISECONDS);

--- a/sample/treino/src/test/resources/behave.properties
+++ b/sample/treino/src/test/resources/behave.properties
@@ -44,3 +44,5 @@ behave.runner.screen.type=MozillaFirefox
 #behave.runner.screen.type=GoogleChrome
 #behave.runner.screen.driverPath=C:\\Documents and Settings\\SERPRO\\Meus documentos\\chromedriver.exe
 #behave.runner.screen.driverPath=//home//Desktop//DB - Browsers//chromedriver
+
+#behave.runner.window.maximize.enabled=true


### PR DESCRIPTION
Permitir o uso da janela do navegador em modo maximizado

Através da propriedade "behave.runner.window.maximize.enabled" em "behave.properties" pode ativa ou não o uso da janela do navegador em modo maximizado.

Ex:
# Ativar o uso da janela do navegador em modo maximizado.

behave.runner.window.maximize.enabled=true
# Desativar o uso da janela do navegador em modo maximizado.

behave.runner.window.maximize.enabled=false

Por padrão o uso da janela do navegador em modo maximizado está desativado.

Ver aplicação de treino.
