### PR TITLE
Permitir alternar de janela no navegador através da url

### DIFF
--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/WebDriverRunner.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/WebDriverRunner.java
@@ -204,9 +204,20 @@ public class WebDriverRunner implements Runner {
 	}
 
 	public void setScreen(String screenName) {
+		String location;
+			
+		try {
+			location = ReflectionUtil.getLocation(screenName);
+		} catch(Exception ex) {
+			location = "";
+		}
+		
 		Set<String> lWindowHandles = driver.getWindowHandles();
 		for (String lWindowHandle : lWindowHandles) {
 			WebDriver lWindow = driver.switchTo().window(lWindowHandle);
+			if (!location.isEmpty() && lWindow.getCurrentUrl().equalsIgnoreCase(location)) {
+				return;
+			}
 			if (lWindow.getTitle().toUpperCase().indexOf(screenName.toUpperCase()) >= 0) {
 				return;
 			}

--- a/sample/mix/src/test/java/demoisellebehave/mix/pages/PopupPage.java
+++ b/sample/mix/src/test/java/demoisellebehave/mix/pages/PopupPage.java
@@ -17,7 +17,7 @@ public class PopupPage {
 
 	}
 
-	@ScreenMap(name = "Nova Janela")
+	@ScreenMap(name = "Outra Janela", location = "http://demoiselle.sourceforge.net/docs/components/behave/samples/new_window.html")
 	public class Popup {
 
 		@ElementMap(name = "Fechar", locatorType = ElementLocatorType.XPath, locator = "//a[./text()='Fechar']")

--- a/sample/mix/src/test/resources/stories/popup/popup.story
+++ b/sample/mix/src/test/resources/stories/popup/popup.story
@@ -11,7 +11,7 @@ Dado que vou para a tela "Janela"
 Então será exibido "Demoiselle Behave - Exemplo com Multiplas Janelas"
 Quando clico em "Nova Guia"
 
-Então estou na tela "Nova Janela"
+Então estou na tela "Outra Janela"
 E será exibido "Outra Janela"
 Então clico em "DBehave"
 
@@ -20,7 +20,7 @@ Então será exibido "Demoiselle Behave"
 Quando clico em "Wiki"
 Então será exibido "Welcome to the dbehave wiki!"
 
-Dado que estou na tela "Nova Janela"
+Dado que estou na tela "Outra Janela"
 Então será exibido "Outra Janela"
 E clico em "Fechar"
 
@@ -29,7 +29,7 @@ Cenário: Pop-up
 Dado que vou para a tela "Janela"
 Então será exibido "Demoiselle Behave - Exemplo com Multiplas Janelas"
 Quando clico em "link POP-up"
-Então estou na tela "Nova Janela"
+Então estou na tela "Outra Janela"
 E será exibido "Outra Janela"
 Então clico em "Fechar"
 Então estou na tela "Janela"


### PR DESCRIPTION
É permitido alternar entre janelas abertas através das frases pré-definidas pelo framework:
Dado que estou na tela "<título da tela>"
Então estou na tela "<título da tela>"
Quando estou na tela "<título da tela>"

Para o caso Web, somente o titulo da janela é usado como identificador da nova janela.

Esta alteração permite também utilizar a url da página corrente na nova janela para fazer a transição.

Será comparado o location do page object com a url da página corrente.

Foi fixado na ordem de busca primeiro a url da página corrente e depois o título da página.

No caso em que o page object não contém location, será considerado somente o título da página.

Exemplo utilizado no projeto mix (popup).
