### PR TITLE
Ajustes para a nova versão do showcase do Primefaces

### DIFF
--- a/sample/mix/src/test/java/demoisellebehave/mix/pages/PrimefacesCheckboxTree.java
+++ b/sample/mix/src/test/java/demoisellebehave/mix/pages/PrimefacesCheckboxTree.java
@@ -5,10 +5,10 @@ import br.gov.frameworkdemoiselle.behave.annotation.ElementMap;
 import br.gov.frameworkdemoiselle.behave.annotation.ScreenMap;
 import br.gov.frameworkdemoiselle.behave.runner.webdriver.ui.primefaces.Tree;
 
-@ScreenMap(name = "Primefaces Checkbox Tree", location = "http://www.primefaces.org/showcase/ui/treeSelectionCheckbox.jsf")
+@ScreenMap(name = "Primefaces Checkbox Tree", location = "http://www.primefaces.org/showcase/ui/data/tree/selection.xhtml")
 public class PrimefacesCheckboxTree {
 
-	@ElementMap(name = "árvore", locatorType = ElementLocatorType.Id, locator = "j_idt19:j_idt20")
+	@ElementMap(name = "árvore", locatorType = ElementLocatorType.Id, locator = "j_idt87:j_idt111")
 	private Tree arvore;
 
 }

--- a/sample/mix/src/test/resources/stories/primefaces/tree.story
+++ b/sample/mix/src/test/resources/stories/primefaces/tree.story
@@ -8,16 +8,16 @@ Desejo manipular o componente Tree Checkbox do PrimeFaces
 Cenário: Expandido e Colapsando nós pelo Label
 
 Dado que vou para a tela "Primefaces Checkbox Tree"
-Então será exibido "Tree - Checkbox Selection"
-Então expando o nó com label "Node 0" do componente "árvore"
-Então expando o nó com label "Node 0.0" do componente "árvore"
-Então colapso o nó com label "Node 0.0" do componente "árvore"
-Então colapso o nó com label "Node 0" do componente "árvore"
+Então será exibido "Checkbox"
+Então expando o nó com label "Documents" do componente "árvore"
+Então expando o nó com label "Work" do componente "árvore"
+Então colapso o nó com label "Work" do componente "árvore"
+Então colapso o nó com label "Documents" do componente "árvore"
 
 Cenário: Expandido e Colapsando nós pelo Caminho
 
 Dado que vou para a tela "Primefaces Checkbox Tree"
-Então será exibido "Tree - Checkbox Selection"
+Então será exibido "Checkbox"
 Então expando o nó com caminho "2" do componente "árvore"
 Então expando o nó com caminho "2.1" do componente "árvore"
 Então colapso o nó com caminho "2.1" do componente "árvore"
@@ -26,18 +26,18 @@ Então colapso o nó com caminho "2" do componente "árvore"
 Cenário: Alternando o checkbox dos nós pelo Label
 
 Dado que vou para a tela "Primefaces Checkbox Tree"
-Então será exibido "Tree - Checkbox Selection"
-Então expando o nó com label "Node 0" do componente "árvore"
-Então expando o nó com label "Node 0.0" do componente "árvore"
-Então alterno o nó com label "Node 0.0" do componente "árvore"
-Então expando o nó com label "Node 1" do componente "árvore"
-Então alterno o nó com label "Node 1" do componente "árvore"
-Então alterno o nó com label "Node 1.0" do componente "árvore"
+Então será exibido "Checkbox"
+Então expando o nó com label "Documents" do componente "árvore"
+Então expando o nó com label "Work" do componente "árvore"
+Então alterno o nó com label "Work" do componente "árvore"
+Então expando o nó com label "Pictures" do componente "árvore"
+Então alterno o nó com label "Pictures" do componente "árvore"
+Então alterno o nó com label "logo.jpg" do componente "árvore"
 
 Cenário: Alternando o checkbox dos nós pelo Caminho
 
 Dado que vou para a tela "Primefaces Checkbox Tree"
-Então será exibido "Tree - Checkbox Selection"
+Então será exibido "Checkbox"
 Então expando o nó com caminho "1" do componente "árvore"
 Então expando o nó com caminho "1.1" do componente "árvore"
 Então alterno o nó com caminho "1.1" do componente "árvore"


### PR DESCRIPTION
A história referente ao componente Tree Checkbox do PrimeFaces usa a página do showcase.

Mudança na página do showcase do Primefaces acarretavam erro na historia.

Ajustes para a nova versão do showcase do Primefaces.
