### PR TITLE
ALMStoryReport alterado para registrar cenários pendentes como 'blocked' no ALM

### DIFF
--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/parser/ScenarioState.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/parser/ScenarioState.java
@@ -1,0 +1,7 @@
+package br.gov.frameworkdemoiselle.behave.parser;
+
+public enum ScenarioState {
+	PASSED,
+	FAILED,
+	PENDING
+}

--- a/impl/integration/alm/src/main/java/br/gov/frameworkdemoiselle/behave/integration/alm/ALMIntegration.java
+++ b/impl/integration/alm/src/main/java/br/gov/frameworkdemoiselle/behave/integration/alm/ALMIntegration.java
@@ -73,6 +73,7 @@ import br.gov.frameworkdemoiselle.behave.integration.alm.httpsclient.HttpsClient
 import br.gov.frameworkdemoiselle.behave.integration.alm.objects.Testplan;
 import br.gov.frameworkdemoiselle.behave.integration.alm.objects.util.GenerateXMLString;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.parser.ScenarioState;
 
 public class ALMIntegration implements Integration {
 
@@ -233,7 +234,8 @@ public class ALMIntegration implements Integration {
 				executionWorkItemUrl = workItemName;
 			}
 
-			HttpResponse responseResult = sendRequest(client, "executionresult", resultName, GenerateXMLString.getExecutionresultString(urlServer, projectAreaAlias, ENCODING, executionWorkItemUrl, Boolean.parseBoolean(result.get("failed").toString()), (Date) result.get("startDate"), (Date) result.get("endDate"), (String) result.get("details")));
+			//HttpResponse responseResult = sendRequest(client, "executionresult", resultName, GenerateXMLString.getExecutionresultString(urlServer, projectAreaAlias, ENCODING, executionWorkItemUrl, Boolean.parseBoolean(result.get("failed").toString()), (Date) result.get("startDate"), (Date) result.get("endDate"), (String) result.get("details")));
+			HttpResponse responseResult = sendRequest(client, "executionresult", resultName, GenerateXMLString.getExecutionresultString(urlServer, projectAreaAlias, ENCODING, executionWorkItemUrl, ((ScenarioState)result.get("state")), (Date) result.get("startDate"), (Date) result.get("endDate"), (String) result.get("details")));
 			if (responseResult.getStatusLine().getStatusCode() != HttpStatus.SC_CREATED) {
 				throw new BehaveException(message.getString("exception-send-result", responseResult.getStatusLine().toString()));
 			}

--- a/impl/integration/alm/src/main/java/br/gov/frameworkdemoiselle/behave/integration/alm/objects/util/GenerateXMLString.java
+++ b/impl/integration/alm/src/main/java/br/gov/frameworkdemoiselle/behave/integration/alm/objects/util/GenerateXMLString.java
@@ -65,6 +65,7 @@ import br.gov.frameworkdemoiselle.behave.integration.alm.objects.TestcaseLink;
 import br.gov.frameworkdemoiselle.behave.integration.alm.objects.Testcasedesign;
 import br.gov.frameworkdemoiselle.behave.integration.alm.objects.Testplan;
 import br.gov.frameworkdemoiselle.behave.integration.alm.objects.TestplanLink;
+import br.gov.frameworkdemoiselle.behave.parser.ScenarioState;
 
 public class GenerateXMLString {
 
@@ -161,7 +162,8 @@ public class GenerateXMLString {
 		return resourceString.toString();
 	}
 
-	public static String getExecutionresultString(String urlServer, String projectAreaAlias, String encoding, String executionWorkItemUrl, Boolean failed, Date _startDate, Date _endDate, String details) throws JAXBException {
+	//public static String getExecutionresultString(String urlServer, String projectAreaAlias, String encoding, String executionWorkItemUrl, Boolean failed, Date _startDate, Date _endDate, String details) throws JAXBException {
+	public static String getExecutionresultString(String urlServer, String projectAreaAlias, String encoding, String executionWorkItemUrl, ScenarioState stateOf, Date _startDate, Date _endDate, String details) throws JAXBException {
 		Date startDate = (Date) _startDate.clone();
 		Date endDate = (Date) _endDate.clone();
 		ApprovalState state = new ApprovalState();
@@ -172,10 +174,19 @@ public class GenerateXMLString {
 		workTest.setHref(executionWorkItemUrl);
 
 		Executionresult result = new Executionresult();
-		if (failed) {
+//		if (failed) {
+//			result.setState("com.ibm.rqm.execution.common.state.failed");
+//		} else {
+//			result.setState("com.ibm.rqm.execution.common.state.passed");
+//		}
+		if(stateOf.equals(ScenarioState.FAILED)){
 			result.setState("com.ibm.rqm.execution.common.state.failed");
-		} else {
-			result.setState("com.ibm.rqm.execution.common.state.passed");
+		}else{
+			if(stateOf.equals(ScenarioState.PENDING)){
+				result.setState("com.ibm.rqm.execution.common.state.blocked");
+			}else{
+				result.setState("com.ibm.rqm.execution.common.state.passed");
+			}
 		}
 		result.setApprovalstate(state);
 		result.setExecutionworkitem(workTest);

--- a/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/report/ALMStoryReport.java
+++ b/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/report/ALMStoryReport.java
@@ -52,6 +52,7 @@ import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.integration.Integration;
 import br.gov.frameworkdemoiselle.behave.internal.spi.InjectionManager;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.parser.ScenarioState;
 import br.gov.frameworkdemoiselle.behave.parser.jbehave.JBehaveParser;
 
 public class ALMStoryReport extends DefaultStoryReport {
@@ -67,6 +68,7 @@ public class ALMStoryReport extends DefaultStoryReport {
 	Hashtable<String, Boolean> failedScenario = new Hashtable<String, Boolean>();
 	Hashtable<String, String> stepsScenario = new Hashtable<String, String>();
 	Hashtable<String, String> details = new Hashtable<String, String>();
+	Hashtable<String, ScenarioState> stateScenario = new Hashtable<String, ScenarioState>();
 
 	Map<String, String> examples;
 
@@ -92,6 +94,7 @@ public class ALMStoryReport extends DefaultStoryReport {
 					scenarioData.put("steps", stepsScenario.get(scenario.getTitle()));
 					scenarioData.put("testPlanId", BehaveConfig.getIntegration_TestPlanId());
 					scenarioData.put("details", "Resultado enviado pelo Demoiselle Behave<br/>" + details.get(scenario.getTitle()));
+					scenarioData.put("state", stateScenario.get(scenario.getTitle()));
 
 					if (meta.hasProperty("casodeteste")) {
 						scenarioData.put("testCaseId", meta.getProperty("casodeteste"));
@@ -136,6 +139,7 @@ public class ALMStoryReport extends DefaultStoryReport {
 		details.put(currentScenarioTitle, message.getString("message-detail-result", step, detail.getMessage()));
 		failedScenario.put(currentScenarioTitle, true);
 		stepsScenario.put(currentScenarioTitle, message.getString("message-error-result", stepsScenario.get(currentScenarioTitle), cause.getCause()));
+		stateScenario.put(currentScenarioTitle, ScenarioState.FAILED);
 	}
 
 	@Override
@@ -156,5 +160,17 @@ public class ALMStoryReport extends DefaultStoryReport {
 		}
 
 		return newStep;
+	}
+
+	@Override
+	public void successful(String step) {
+		super.successful(step);
+		stateScenario.put(currentScenarioTitle, ScenarioState.PASSED);
+	}
+
+	@Override
+	public void pending(String step) {
+		super.pending(step);
+		stateScenario.put(currentScenarioTitle, ScenarioState.PENDING);
 	}
 }


### PR DESCRIPTION
Com essa alteração, os cenários pendentes, agora são marcados no ALM como [blocked](http://open-services.net/bin/view/Main/QmExecutionAdapter), ou seja:
Verde: ScenarioState.PASSED - com.ibm.rqm.execution.common.state.passed
Vermelho: ScenarioState.FAILED - com.ibm.rqm.execution.common.state.failed
Amarelo: ScenarioState.PENDING - com.ibm.rqm.execution.common.state.blocked

![imagem](https://cloud.githubusercontent.com/assets/687967/5075088/495413a6-6e77-11e4-9751-0085ba26e676.png)
