### PR TITLE
Capturar o objeto encapsulado em uma instância de UIProxy

### DIFF
--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/ui/UIProxy.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/ui/UIProxy.java
@@ -1,5 +1,6 @@
 package br.gov.frameworkdemoiselle.behave.internal.ui;
 
+import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.util.GregorianCalendar;
 
@@ -9,7 +10,7 @@ import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
 
-public class UIProxy implements java.lang.reflect.InvocationHandler {
+public class UIProxy implements InvocationHandler {
 
 	private Object obj;
 	Logger log = Logger.getLogger(UIProxy.class);
@@ -58,5 +59,29 @@ public class UIProxy implements java.lang.reflect.InvocationHandler {
 
 		}
 
+	}
+	
+	/**
+	 * Retorna o objeto de uma instância do proxy
+	 * 
+	 * Obs: Ideal para capturar a instancia real
+	 * 		do proxy, não somente pela interface 
+	 * 		que o implementa
+	 * 
+	 * @param proxyInstance Instância que contém um objeto da sua classe real encapsulada
+	 * @return Objeto real da instância do proxy
+	 */
+	public static InvocationHandler getHandler(Object proxyInstance){
+		
+		return (InvocationHandler) java.lang.reflect.Proxy.getInvocationHandler(proxyInstance);
+	}
+	
+	/**
+	 * Captura o objeto real encapsulado pelo proxy
+	 * 
+	 * @return
+	 */
+	public Object getObj(){
+		return this.obj;
 	}
 }


### PR DESCRIPTION
Em algumas situações pontuais e bem simples, as vezes é necessário ter acesso ao `WebElement` de um determinado campo mapeado nas pages, dentro de uma classe de Steps específica de um projeto, ou até mesmo na classe `CommonSteps`. Na versão **_1.3.0_** não existia a classe `UIProxy` que herda de `InvocatioHandler`, e por isso, só me deparei com esta "dificuldade" na migração para a versão **_1.4.0_**.

A solução de contorno aqui proposta, é expor o objeto encapsulado no atributo `UIProxy#obj` através de um simples método `getObj()`. Sem este pull request incorporado a versão atual, precisei utilizar **_Reflection_** para ter acesso ao atributo privado :disappointed:

**Pergunta:** Caso este pull request seja aceito, qual o procedimento para que esta alteração esteja disponível ao adicionar no _pom.xml_ a versão 1.4.0 ?? Existe algum fluxo de trabalho para incorporar os pull requests para o repositório maven do Demoiselle Behave?
