### PR TITLE
Alteração do mapeamento do componente Logotipo

### DIFF
--- a/sample/search-google/src/test/java/demoisellebehave/sample/google/test/pages/SearchPage.java
+++ b/sample/search-google/src/test/java/demoisellebehave/sample/google/test/pages/SearchPage.java
@@ -46,7 +46,7 @@ import br.gov.frameworkdemoiselle.behave.runner.ui.TextField;
 @ScreenMap(name = "Tela de Busca", location = "http://www.google.com.br")
 public class SearchPage {
 
-	@ElementMap(name = "Logotipo", locatorType = ElementLocatorType.XPath, locator = "//div[@title='%param1%']")
+	@ElementMap(name = "Logotipo Google", locatorType = ElementLocatorType.XPath, locator = "//div[@id='hplogo']/a/img")
 	private Image logotipo;
 	
 	@ElementMap(name = "Campo de Busca", locatorType = ElementLocatorType.Name, locator = "q")

--- a/sample/search-google/src/test/resources/stories/acesso.story
+++ b/sample/search-google/src/test/resources/stories/acesso.story
@@ -9,7 +9,7 @@ Desejo acessar o Google
 Cenário: Acesso ao "{sistema}"
 
 Dado que vou para a tela "Tela de Busca"
-Então aguardo o elemento "Logotipo" referente a "{sistema}" estar visível, clicável e habilitado
+Então aguardo o elemento "Logotipo {sistema}" estar visível, clicável e habilitado
 Então aguardo o elemento "Campo de Busca" estar visível, clicável e habilitado
 Então aguardo o elemento "Estou com sorte" estar visível, clicável e habilitado
 


### PR DESCRIPTION
Alteração do mapeamento do componente Logotipo:

- Uso do parâmetro do cenário reutilizado no nome do elemento da tela