### PR TITLE
Zoom out para screenshot (via behave.config)

### DIFF
--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/config/BehaveConfig.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/config/BehaveConfig.java
@@ -269,6 +269,11 @@ public class BehaveConfig {
 		return Boolean.parseBoolean(getProperty("behave.runner.window.maximize.enabled", "false"));
 	}
 
+	// Níves de zoom out que o framework realizará antes de capturar a tela
+	 public static int getRunner_screenShotZoomout() {
+		return Integer.parseInt(getProperty("behave.runner.screen.screenshot.zoomout", "0"));
+	 }
+	 
 	/*
 	 * Configurações especificas para testes Desktop
 	 */

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/WebDriverRunner.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/WebDriverRunner.java
@@ -48,11 +48,15 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Dimension;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.UnsupportedCommandException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.WebElement;
 
 import br.gov.frameworkdemoiselle.behave.annotation.ElementMap;
 import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
@@ -190,7 +194,21 @@ public class WebDriverRunner implements Runner {
 		File screenshotFile = new File(fileName);
 
 		screenshotFile.getParentFile().mkdirs();
+		
+		Dimension d = driver.manage().window().getSize();
+		
+		driver.manage().window().maximize();
+		WebElement html = driver.findElement(By.tagName("html"));
+		
+		for (int x=0; x< BehaveConfig.getRunner_screenShotZoomout();x++){
+			html.sendKeys(Keys.chord(Keys.CONTROL, Keys.SUBTRACT));
+		}
+		
 		File screenshot = ((TakesScreenshot) driver).getScreenshotAs(OutputType.FILE);
+		
+		driver.manage().window().setSize(d);
+		html.sendKeys(Keys.chord(Keys.CONTROL, "0"));
+		
 		try {
 			FileUtils.copyFile(screenshot, new File(screenshotFile.getAbsolutePath()));
 


### PR DESCRIPTION
Quando ocorre um erro, o sistema captura a tela e muitas vezes a informação que marca o erro fica "fora da tela".

Esta melhoria cria um atributo novo no behave.properties na qual o
usuário pode escolher quantos níveis de zoom out ele quer na tela
capturada. Ela também sempre maximiza a janela antes do print da tela (e
depois retorna ao tamanho original do usuário) para maximizar a chance
de retratar no print o erro ocorrido.

#Habilita zoom out para as capturas de tela quando ocorrem problemas na
execução das histórias 
#behave.runner.screen.screenshot.zoomout = 4