### PR TITLE
Criada a palavra chave Subcenário.

### DIFF
--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/parser/StoryConverter.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/parser/StoryConverter.java
@@ -304,7 +304,11 @@ public class StoryConverter {
 		if (!scenario.getIdentification().toLowerCase().equals(scenario.getIdentificationWithoutParametersName().toLowerCase())) {
 			scenario.setReusable(true);
 		}
-
+		
+		if (scenarioToken.toLowerCase().startsWith("sub")){
+			scenario.setReusable(true);
+		}
+	
 		return scenario;
 	}
 

--- a/impl/core/src/main/resources/behave.properties
+++ b/impl/core/src/main/resources/behave.properties
@@ -8,10 +8,10 @@ behave.message.locale=pt
 # Parser Configuration
 behave.parser.language=pt
 
-behave.parser.identification.scenario.pattern.en=^(\\s)*(SCENARIO|Scenario|scenario)\:(.*)
+behave.parser.identification.scenario.pattern.en=^(\\s)*(SCENARIO|Scenario|scenario|SUBSCENARIO|Subscenario)\:(.*)
 behave.parser.prefixes.bdd.pattern.en=^(\\s)*(GIVEN |WHEN |THEN |AND |BUT |Given |When |Then |And |But |given |when |then |and |but )(.*)
 
-behave.parser.identification.scenario.pattern.pt=^(\\s)*(CEN\u00C1RIO|Cen\u00E1rio|cen\u00E1rio)\:(.*)
+behave.parser.identification.scenario.pattern.pt=^(\\s)*(CEN\u00C1RIO|Cen\u00E1rio|cen\u00E1rio|SUBCEN\u00C1RIO|Subcen\u00E1rio)\:(.*)
 behave.parser.prefixes.bdd.pattern.pt=^(\\s)*(DADO |QUANDO |ENT\u00C3O |E |MAS |Dado |Quando |Ent\u00E3o |Mas |dado |quando |ent\u00E3o |e |mas )(.*)
 
 behave.parser.story.extension.original=bdd


### PR DESCRIPTION
Quando se deseja que um cenário seja reutilizável, mas ele não tem
necessidade de receber parâmetros, você é forçado a criar um parâmetro
"fake". Com a declaração de Subcenário, agora é possível criar cenários
reutilizáveis sem a necessidade de um parâmetro falso.

Exemplo:
Subcenário: teste de cenário reutilizável sem parâmetros