### PR TITLE
Padronização no comportamento do Radio e do Checkbox

### DIFF
--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/runner/ui/Radio.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/runner/ui/Radio.java
@@ -45,4 +45,6 @@ public interface Radio extends BaseUI {
 
 	public void click();
 	
+	public Boolean isSelected();
+	
 }

--- a/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopCheckBox.java
+++ b/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopCheckBox.java
@@ -53,7 +53,7 @@ public class DesktopCheckBox extends DesktopBase implements CheckBox {
 
 	@Override
 	public Boolean isSelected() {
-		return null;
+		return ((JCheckBox) getElement()).isSelected();
 	}
 
 }

--- a/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopRadio.java
+++ b/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopRadio.java
@@ -50,5 +50,10 @@ public class DesktopRadio extends DesktopBase implements Radio {
 		
 		radioFix.click();
 	}
+	
+	@Override
+	public Boolean isSelected() {
+		return ((JRadioButton) getElement()).isSelected();
+	}
 
 }

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebRadio.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebRadio.java
@@ -46,4 +46,10 @@ public class WebRadio extends WebBase implements Radio {
 		getElements().get(0).click();
 	}
 
+	public Boolean isSelected() {
+		waitVisibleClickableEnabled();
+		
+		return getElements().get(0).isSelected();
+	}
+
 }


### PR DESCRIPTION
Padronização no comportamento do Radio e do Checkbox

Tanto o Radio como o Checkbox terem a possibilidade de verificar se estão marcados ou não.

No futuro, verificar a possibilidade de o Checkbox ter ou não um terceiro estado.