### PR TITLE
Melhorias para testes de Destkop

### DIFF
--- a/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopBase.java
+++ b/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopBase.java
@@ -3,32 +3,32 @@
  * Copyright (C) 2013 SERPRO
  * ----------------------------------------------------------------------------
  * This file is part of Demoiselle Framework.
- * 
+ *
  * Demoiselle Framework is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License version 3
  * as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License version 3
  * along with this program; if not,  see <http://www.gnu.org/licenses/>
  * or write to the Free Software Foundation, Inc., 51 Franklin Street,
  * Fifth Floor, Boston, MA  02110-1301, USA.
  * ----------------------------------------------------------------------------
  * Este arquivo é parte do Framework Demoiselle.
- * 
+ *
  * O Framework Demoiselle é um software livre; você pode redistribuí-lo e/ou
  * modificá-lo dentro dos termos da GNU LGPL versão 3 como publicada pela Fundação
  * do Software Livre (FSF).
- * 
+ *
  * Este programa é distribuído na esperança que possa ser útil, mas SEM NENHUMA
  * GARANTIA; sem uma garantia implícita de ADEQUAÇÃO a qualquer MERCADO ou
  * APLICAÇÃO EM PARTICULAR. Veja a Licença Pública Geral GNU/LGPL em português
  * para maiores detalhes.
- * 
+ *
  * Você deve ter recebido uma cópia da GNU LGPL versão 3, sob o título
  * "LICENCA.txt", junto com esse programa. Se não, acesse <http://www.gnu.org/licenses/>
  * ou escreva para a Fundação do Software Livre (FSF) Inc.,
@@ -42,6 +42,7 @@ import java.util.Collection;
 
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
+import javax.swing.JComponent;
 import javax.swing.JFileChooser;
 import javax.swing.JLabel;
 import javax.swing.JMenu;
@@ -67,7 +68,7 @@ import br.gov.frameworkdemoiselle.behave.runner.ui.BaseUI;
 
 public class DesktopBase extends DesktopMappedElement implements BaseUI {
 
-	private BehaveMessage message = new BehaveMessage(FestRunner.MESSAGEBUNDLE);
+	protected BehaveMessage message = new BehaveMessage(FestRunner.MESSAGEBUNDLE);
 	private Logger log = Logger.getLogger(DesktopBase.class);
 	protected FestRunner runner = (FestRunner) getRunner();
 
@@ -99,7 +100,7 @@ public class DesktopBase extends DesktopMappedElement implements BaseUI {
 	}
 
 	/**
-	 * 
+	 *
 	 * @param component
 	 * @return
 	 */
@@ -250,6 +251,18 @@ public class DesktopBase extends DesktopMappedElement implements BaseUI {
 			Thread.sleep(delay);
 		} catch (InterruptedException ex) {
 			throw new BehaveException(message.getString("exception-thread-sleep"), ex);
+		}
+	}
+
+	@Override
+	public void isVisibleDisabled() {
+		JComponent component = (JComponent) getElement();
+		if (component == null) {
+			throw new BehaveException(message.getString("exception-element-not-found", getElementMap().name()));
+		} else {
+			if (!component.isVisible() || component.isEnabled()) {
+				throw new BehaveException(message.getString("exception-element-not-displayed-or-enabled", getElementMap().name()));
+			}
 		}
 	}
 

--- a/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopSelect.java
+++ b/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopSelect.java
@@ -1,0 +1,91 @@
+/*
+ * Demoiselle Framework
+ * Copyright (C) 2013 SERPRO
+ * ----------------------------------------------------------------------------
+ * This file is part of Demoiselle Framework.
+ *
+ * Demoiselle Framework is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License version 3
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this program; if not,  see <http://www.gnu.org/licenses/>
+ * or write to the Free Software Foundation, Inc., 51 Franklin Street,
+ * Fifth Floor, Boston, MA  02110-1301, USA.
+ * ----------------------------------------------------------------------------
+ * Este arquivo é parte do Framework Demoiselle.
+ *
+ * O Framework Demoiselle é um software livre; você pode redistribuí-lo e/ou
+ * modificá-lo dentro dos termos da GNU LGPL versão 3 como publicada pela Fundação
+ * do Software Livre (FSF).
+ *
+ * Este programa é distribuído na esperança que possa ser útil, mas SEM NENHUMA
+ * GARANTIA; sem uma garantia implícita de ADEQUAÇÃO a qualquer MERCADO ou
+ * APLICAÇÃO EM PARTICULAR. Veja a Licença Pública Geral GNU/LGPL em português
+ * para maiores detalhes.
+ *
+ * Você deve ter recebido uma cópia da GNU LGPL versão 3, sob o título
+ * "LICENCA.txt", junto com esse programa. Se não, acesse <http://www.gnu.org/licenses/>
+ * ou escreva para a Fundação do Software Livre (FSF) Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA 02111-1301, USA.
+ */
+package br.gov.frameworkdemoiselle.behave.runner.fest.ui;
+
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+
+import org.fest.swing.fixture.JComboBoxFixture;
+
+import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.runner.fest.FestRunner;
+import br.gov.frameworkdemoiselle.behave.runner.ui.Select;
+
+public class DesktopSelect extends DesktopBase implements Select {
+	private static BehaveMessage message = new BehaveMessage(FestRunner.MESSAGEBUNDLE);
+
+	@Override
+	public void isVisibleDisabled() {
+		JComponent component = (JComponent) getElement();
+		if (component == null) {
+			throw new BehaveException(message.getString("exception-element-not-found", getElementMap().name()));
+		} else {
+			if (!component.isVisible() || component.isEnabled()) {
+				throw new BehaveException(message.getString("exception-element-not-displayed-or-enabled", getElementMap().name()));
+			}
+		}
+	}
+
+	@Override
+	public String getText() {
+		JComboBoxFixture comboFixture = new JComboBoxFixture(runner.robot, (JComboBox) getElement());
+		if (comboFixture.component() != null && comboFixture.component().getSelectedItem() != null) {
+			return comboFixture.component().getSelectedItem().toString();
+		} else {
+			return null;
+		}
+	}
+
+	@Override
+	public void selectByVisibleText(String value) {
+		selectByValue(value);
+	}
+
+	@Override
+	public void selectByIndex(int index) {
+		JComboBoxFixture comboFixture = new JComboBoxFixture(runner.robot, (JComboBox) getElement());
+		comboFixture.selectItem(index);
+	}
+
+	@Override
+	public void selectByValue(String value) {
+		JComboBoxFixture comboFixture = new JComboBoxFixture(runner.robot, (JComboBox) getElement());
+		comboFixture.selectItem(value);
+	}
+
+}

--- a/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopTextField.java
+++ b/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopTextField.java
@@ -3,32 +3,32 @@
  * Copyright (C) 2013 SERPRO
  * ----------------------------------------------------------------------------
  * This file is part of Demoiselle Framework.
- * 
+ *
  * Demoiselle Framework is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License version 3
  * as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License version 3
  * along with this program; if not,  see <http://www.gnu.org/licenses/>
  * or write to the Free Software Foundation, Inc., 51 Franklin Street,
  * Fifth Floor, Boston, MA  02110-1301, USA.
  * ----------------------------------------------------------------------------
  * Este arquivo é parte do Framework Demoiselle.
- * 
+ *
  * O Framework Demoiselle é um software livre; você pode redistribuí-lo e/ou
  * modificá-lo dentro dos termos da GNU LGPL versão 3 como publicada pela Fundação
  * do Software Livre (FSF).
- * 
+ *
  * Este programa é distribuído na esperança que possa ser útil, mas SEM NENHUMA
  * GARANTIA; sem uma garantia implícita de ADEQUAÇÃO a qualquer MERCADO ou
  * APLICAÇÃO EM PARTICULAR. Veja a Licença Pública Geral GNU/LGPL em português
  * para maiores detalhes.
- * 
+ *
  * Você deve ter recebido uma cópia da GNU LGPL versão 3, sob o título
  * "LICENCA.txt", junto com esse programa. Se não, acesse <http://www.gnu.org/licenses/>
  * ou escreva para a Fundação do Software Livre (FSF) Inc.,
@@ -40,6 +40,7 @@ import javax.swing.text.JTextComponent;
 
 import org.fest.swing.fixture.JTextComponentFixture;
 
+import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.runner.ui.TextField;
 
 public class DesktopTextField extends DesktopBase implements TextField {
@@ -65,5 +66,17 @@ public class DesktopTextField extends DesktopBase implements TextField {
 		JTextComponentFixture textFix = new JTextComponentFixture(runner.robot, (JTextComponent) getElement());
 		return textFix.text();
 	}
-	
+
+	@Override
+	public void isVisibleDisabled() {
+		JTextComponent component = (JTextComponent) getElement();
+		if (component == null) {
+			throw new BehaveException(message.getString("exception-element-not-found", getElementMap().name()));
+		} else {
+			//Alguns componentens usam isEditable e outros usam isEnabled
+			if (!component.isVisible() || (component.isEditable() && component.isEnabled())) {
+				throw new BehaveException(message.getString("exception-element-not-displayed-or-enabled", getElementMap().name()));
+			}
+		}
+	}
 }


### PR DESCRIPTION
Pessoal,

Seguem algumas pequenas melhorias que criamos para nossos testes de Java Desktop:

- Criação do componente `DesktopSelect`, que permite a seleção de valores em combos;
- Implementação do método `isVisibleDisabled()`, tanto para componentes em geral como especificamente para `JTextField`;