### PR TITLE
Melhorias no método waitNotVisibleText da classe WebBase.

### DIFF
--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebBase.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebBase.java
@@ -533,7 +533,8 @@ public class WebBase extends MappedElement implements BaseUI {
 					for (WebElement element : elementsFound) {
 						if (element.getText().contains(text)) {
 							found = true;
-							break;
+							// achou o texto, quando o esperado era não achar...
+							throw new BehaveException(message.getString("message-text-found", text));
 						}
 					}
 				}
@@ -551,7 +552,8 @@ public class WebBase extends MappedElement implements BaseUI {
 							for (WebElement element : elementsFound) {
 								if (element.getText().contains(text)) {
 									found = true;
-									break;
+									// achou o texto, quando o esperado era não achar...
+									throw new BehaveException(message.getString("message-text-found", text));
 								}
 							}
 						}
@@ -571,13 +573,11 @@ public class WebBase extends MappedElement implements BaseUI {
 				driver.manage().timeouts().implicitlyWait(BehaveConfig.getRunner_ScreenMaxWait(), TimeUnit.MILLISECONDS);
 			}
 
-			if (!found) {
-				break;
-			}
-
 			waitThreadSleep(BehaveConfig.getRunner_ScreenMinWait());
 			if ((GregorianCalendar.getInstance().getTimeInMillis() - startedTime) > BehaveConfig.getRunner_ScreenMaxWait()) {
-				Assert.fail(message.getString("message-text-found", text));
+				// Se já passou mais tempo que o esperado em BehaveConfig.getRunner_ScreenMaxWait(),
+				//  assume-se que o texto realmente não estava presente na página, como desejado.
+				break;
 			}
 
 		}


### PR DESCRIPTION
1) No caso do texto ter sido encontrado, ele ainda persistia no loop,
procurando, até finalizar o tempo máximo de
BehaveConfig.getRunner_ScreenMaxWait().
Porém, se achou (e não deveria ter achado), ao invés de esperar, que
seja disparada logo uma exceção.

2) No caso do texto não ter sido encontrado, numa primeira passada, o
bloco "if (!found)" foi removido para não impedir do DBehave persistir
pelo tempo previsto.
Se realmente, dentro deste tempo, não for encontrado, aí o método será
finalizado, assumindo que realmente não foi exibido o texto na página (o
que, no escopo deste método, é o desejado).
