### PR TITLE
Declaração da implementação da interface Select para aplicações desktop.

### DIFF
--- a/impl/runner/fest/src/main/resources/META-INF/services/br.gov.frameworkdemoiselle.behave.runner.ui.Select
+++ b/impl/runner/fest/src/main/resources/META-INF/services/br.gov.frameworkdemoiselle.behave.runner.ui.Select
@@ -1,0 +1,1 @@
+br.gov.frameworkdemoiselle.behave.runner.fest.ui.DesktopSelect


### PR DESCRIPTION
@juliancesar , a classe `br.gov.frameworkdemoiselle.behave.runner.fest.ui.DesktopSelect` foi incorporada na versão `1.5.2`, mas não está declarada no arquivo de configurações, o que causa uma exceção ao tentar passos deste tipo de componente em testes em ambiente Desktop.

Segue a correção nesta pull request.