### PR TITLE
Alterações no runner Fest

### DIFF
--- a/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopBase.java
+++ b/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopBase.java
@@ -114,6 +114,7 @@ public class DesktopBase extends DesktopMappedElement implements BaseUI {
 
 		if (component instanceof JButton) {
 			JButton button = (JButton) component;
+			
 			switch (locatorType) {
 			case Name:
 				if (button.getName() != null && button.getName().equalsIgnoreCase(locator))
@@ -129,10 +130,10 @@ public class DesktopBase extends DesktopMappedElement implements BaseUI {
 			default:
 				break;
 			}
-		}
-
-		if (component instanceof JComboBox) {
+			
+		} else if (component instanceof JComboBox) {
 			JComboBox combo = (JComboBox) component;
+			
 			switch (locatorType) {
 			case Name:
 				if (combo.getName() != null && combo.getName().equalsIgnoreCase(locator))
@@ -144,10 +145,10 @@ public class DesktopBase extends DesktopMappedElement implements BaseUI {
 			default:
 				break;
 			}
-		}
-
-		if (component instanceof JTextField) {
+			
+		} else if (component instanceof JTextField) {
 			JTextField textField = (JTextField) component;
+			
 			switch (locatorType) {
 			case Name:
 				if (textField.getName() != null && textField.getName().equalsIgnoreCase(locator))
@@ -163,10 +164,10 @@ public class DesktopBase extends DesktopMappedElement implements BaseUI {
 			default:
 				break;
 			}
-		}
-
-		if (component instanceof JLabel) {
+			
+		} else if (component instanceof JLabel) {
 			JLabel label = (JLabel) component;
+			
 			switch (locatorType) {
 			case Name:
 				if (label.getName() != null && label.getName().equalsIgnoreCase(locator))
@@ -182,10 +183,10 @@ public class DesktopBase extends DesktopMappedElement implements BaseUI {
 			default:
 				break;
 			}
-		}
-
-		if (component instanceof JSpinner) {
+			
+		} else if (component instanceof JSpinner) {
 			JSpinner spinner = (JSpinner) component;
+			
 			switch (locatorType) {
 			case Name:
 				if (spinner.getName() != null && spinner.getName().equalsIgnoreCase(locator))
@@ -197,10 +198,9 @@ public class DesktopBase extends DesktopMappedElement implements BaseUI {
 			default:
 				break;
 			}
-		}
-
-		if (component instanceof JMenu) {
+		} else if (component instanceof JMenu) {
 			JMenu menu = (JMenu) component;
+			
 			switch (locatorType) {
 			case Name:
 				if (menu.getName() != null && menu.getName().equalsIgnoreCase(locator))
@@ -216,10 +216,10 @@ public class DesktopBase extends DesktopMappedElement implements BaseUI {
 			default:
 				break;
 			}
-		}
-
-		if (component instanceof JMenuItem) {
+			
+		} else if (component instanceof JMenuItem) {
 			JMenuItem menuItem = (JMenuItem) component;
+			
 			switch (locatorType) {
 			case Name:
 				if (menuItem.getName() != null && menuItem.getName().equalsIgnoreCase(locator))
@@ -235,10 +235,10 @@ public class DesktopBase extends DesktopMappedElement implements BaseUI {
 			default:
 				break;
 			}
-		}
-
-		if (component instanceof JCheckBox) {
+			
+		} else if (component instanceof JCheckBox) {
 			JCheckBox checkBox = (JCheckBox) component;
+			
 			switch (locatorType) {
 			case Name:
 				if (checkBox.getName() != null && checkBox.getName().equalsIgnoreCase(locator))
@@ -254,10 +254,10 @@ public class DesktopBase extends DesktopMappedElement implements BaseUI {
 			default:
 				break;
 			}
-		}
-
-		if (component instanceof JRadioButton) {
+			
+		} else if (component instanceof JRadioButton) {
 			JRadioButton radio = (JRadioButton) component;
+			
 			switch (locatorType) {
 			case Name:
 				if (radio.getName() != null && radio.getName().equalsIgnoreCase(locator))
@@ -273,9 +273,8 @@ public class DesktopBase extends DesktopMappedElement implements BaseUI {
 			default:
 				break;
 			}
-		}
-
-		if (component instanceof JFileChooser) {
+			
+		} else if (component instanceof JFileChooser) {
 			JFileChooser fileChooser = (JFileChooser) component;
 			switch (locatorType) {
 			case Name:
@@ -288,9 +287,7 @@ public class DesktopBase extends DesktopMappedElement implements BaseUI {
 			default:
 				break;
 			}
-		}
-
-		if (component instanceof JTabbedPane) {
+		} else if (component instanceof JTabbedPane) {
 			JTabbedPane tabbedPane = (JTabbedPane) component;
 
 			for (int i = 0; i < tabbedPane.getComponentCount(); i++) {
@@ -300,14 +297,16 @@ public class DesktopBase extends DesktopMappedElement implements BaseUI {
 				else if (locatorType == ElementLocatorType.ClassName && locator.equals("JTabbedPane"))
 					return true;
 			}
-		}
-
-		if (component instanceof JTable) {
+			
+		} else if (component instanceof JTable) {
+			
 			if (locatorType == ElementLocatorType.ClassName && locator.equals("JTable"))
 				return true;
+			
 		}
-
+		
 		if (component.getClass().getCanonicalName() != null && locatorType == ElementLocatorType.ClassName && component.getClass().getCanonicalName().equalsIgnoreCase(locator)) {
+			
 			try {
 				Method isShowingMethod = component.getClass().getMethod("isShowing");
 				boolean isShowing = (Boolean) isShowingMethod.invoke(component);
@@ -320,12 +319,14 @@ public class DesktopBase extends DesktopMappedElement implements BaseUI {
 					String locatorAux = getLocatorWithParameters(getElementMap().locator()[1]);
 					return resultado.equalsIgnoreCase(locatorAux);
 				}
-			}
-			catch (Exception e) {
+				
+			} catch (Exception e) {
 				return false;
 			}
+			
 			return true;
 		}
+		
 		return false;
 	}
 

--- a/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopScreen.java
+++ b/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopScreen.java
@@ -36,10 +36,14 @@
  */
 package br.gov.frameworkdemoiselle.behave.runner.fest.ui;
 
-import junit.framework.Assert;
+import java.util.GregorianCalendar;
+
+import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
+import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
 import br.gov.frameworkdemoiselle.behave.runner.fest.FestRunner;
 import br.gov.frameworkdemoiselle.behave.runner.ui.Screen;
+import junit.framework.Assert;
 
 public class DesktopScreen extends DesktopBase implements Screen {
 
@@ -49,7 +53,30 @@ public class DesktopScreen extends DesktopBase implements Screen {
 		waitText(text, 0L);
 	}
 
-	public void waitText(String text, Long timeout) {
-		Assert.assertTrue(message.getString("exception-text-not-found", text), super.runner.getHierarchy().contains("text='" + text + "'"));
+	public void waitText(String text, Long timeout) {		
+		boolean found = false;
+		long startedTime = GregorianCalendar.getInstance().getTimeInMillis();
+
+		while (true) {
+
+			try {				
+				found = super.runner.getHierarchy().contains("text='" + text + "'");				
+			} catch (BehaveException be) {
+				throw be;
+			} catch (Exception e) {
+				throw new BehaveException(message.getString("exception-unexpected", e.getMessage()), e);
+			}
+
+			if (found) {
+				break;
+			}
+
+			waitThreadSleep(BehaveConfig.getRunner_ScreenMinWait());
+			if ((GregorianCalendar.getInstance().getTimeInMillis() - startedTime) > BehaveConfig.getRunner_ScreenMaxWait()) {
+				Assert.fail(message.getString("message-text-not-found", text));
+			}
+
+		}
+				
 	}
 }

--- a/impl/runner/fest/src/main/resources/demoiselle-runner-fest-bundle_en.properties
+++ b/impl/runner/fest/src/main/resources/demoiselle-runner-fest-bundle_en.properties
@@ -54,3 +54,4 @@ exception-elements-not-found=Element not found. \rContainer: \r{0}\r------------
 exception-thread-sleep=Thread sleep interrupted
 exception-text-not-found=Text [{0}] not found
 exception-error-resize-image=Error resize the image [{0}]
+exception-active-window-not-found=Single active window not found. Number of active windows: {0} \rContainer: \r{1}\r----------------------------------------------\r\uObjects tree: \r{2}\r----------------------------------------------

--- a/impl/runner/fest/src/main/resources/demoiselle-runner-fest-bundle_pt.properties
+++ b/impl/runner/fest/src/main/resources/demoiselle-runner-fest-bundle_pt.properties
@@ -54,3 +54,4 @@ exception-elements-not-found=Elemento n\u00E3o encontrado. \rContainer: \r{0}\r-
 exception-thread-sleep=Thread sleep interrompido
 exception-text-not-found=Texto [{0}] n\u00E3o encontrado
 exception-error-resize-image=Erro ao redimensionar a imagem [{0}]
+exception-active-window-not-found=Janela \u00FAnica ativa n\u00E3o encontrada. N\u00FAmero de janelas ativas: {0} \rContainer: \r{1}\r----------------------------------------------\r\u00C1rvore de objetos: \r{2}\r----------------------------------------------


### PR DESCRIPTION
Foram feitas alterações no runner Fest para:

- aguardar componente na tela: o método "waitText" não estava aguardando o componente, como deveria ser. Foi adicionado processo para aguardar por um período.

- fazer busca por componentes iniciar a partir da tela ativa: antes a busca por um componente se dava a partir da tela principal, o que não estava deixando funcionar os índices dos componentes, pois, há telas que, quando chamadas, não destroem seus componentes imediatamente e, quando chamadas várias vezes, deixa vários componentes "iguais" ativos, fazendo com que os índices ajustados no mapeamento não funcionem.

- eliminar comparações desnecessárias na busca por componentes: havia vários "ifs" fora de "elses", o que fazia com que todos os "ifs" fossem percorridos sempre.