### PR TITLE
Adicionados passos para manipular janela de seleção de arquivo

### DIFF
--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/runner/Runner.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/runner/Runner.java
@@ -59,6 +59,8 @@ public interface Runner {
 	public String getTitle();
 
 	public Element getElement(String currentPageName, String elementName);
+	
+	public Element getElement(Class<?> elementClass);
 
 	public String getPageSource();
 

--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/runner/ui/FileUpload.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/runner/ui/FileUpload.java
@@ -45,4 +45,9 @@ public interface FileUpload extends BaseUI {
 
 	public void sendKeys(CharSequence... keysToSend);
 	
+	public void cancel();
+	
+	public void setCurrentDirectory(String dirPath);
+	
+	public void openFile(String fileName);
 }

--- a/impl/core/src/main/resources/demoiselle-behave-core-bundle_en.properties
+++ b/impl/core/src/main/resources/demoiselle-behave-core-bundle_en.properties
@@ -65,3 +65,5 @@ exception-duplicate-history-file=The file of history [{0}] was added twice, plea
 exception-legacyRunner-true=Legacy mode must be set to true in "behave.properties".
 exception-legacyRunner-false=Legacy mode must be set to false in "behave.properties".
 exception-legacyRunner-classScopeManager-missing=Your test class is missing "ClassScopeManager".
+exception-method-not-implemented=Method \"{0}\" not implemented yet.
+exception-method-not-implemented-for-type=Method \"{0}\" not implemented yet for type \"{1}\".

--- a/impl/core/src/main/resources/demoiselle-behave-core-bundle_pt.properties
+++ b/impl/core/src/main/resources/demoiselle-behave-core-bundle_pt.properties
@@ -65,3 +65,5 @@ exception-duplicate-history-file=O arquivo de hist\u00F3ria [{0}] foi adicionado
 exception-legacyRunner-true=O modo legado dever\u00E1 estar habilitado no "behave.properties" para utilizar esta funcionalidade.
 exception-legacyRunner-false=O modo legado dever\u00E1 estar desabilitado no behave.properties para utilizar esta funcionalidade.O modo legado dever\u00E1 estar desabilitado no behave.properties para utilizar esta funcionalidade.
 exception-legacyRunner-classScopeManager-missing=Sua classe de teste deve estender a classe "ClassScopeManager".
+exception-method-not-implemented=M\u00E9todo \"{0}\" ainda n\u00E3o implementado.
+exception-method-not-implemented-for-type=M\u00E9todo \"{0}\" ainda n\u00E3o implementado para o tipo \"{1}\".

--- a/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/CommonSteps.java
+++ b/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/CommonSteps.java
@@ -58,6 +58,7 @@ import br.gov.frameworkdemoiselle.behave.runner.ui.Button;
 import br.gov.frameworkdemoiselle.behave.runner.ui.Calendar;
 import br.gov.frameworkdemoiselle.behave.runner.ui.CheckBox;
 import br.gov.frameworkdemoiselle.behave.runner.ui.Element;
+import br.gov.frameworkdemoiselle.behave.runner.ui.FileUpload;
 import br.gov.frameworkdemoiselle.behave.runner.ui.Grid;
 import br.gov.frameworkdemoiselle.behave.runner.ui.Link;
 import br.gov.frameworkdemoiselle.behave.runner.ui.Menu;
@@ -460,6 +461,27 @@ public class CommonSteps implements Step {
 			((Tree) element).clickTreeRow(Integer.parseInt(row));
 		else
 			throw new BehaveException(message.getString("exception-invalid-type", element.getClass().getName()));
+	}
+	
+	@When(value = "cancelo a sele\u00E7\u00E3o de arquivo", priority = 1)
+	@Then(value = "cancelo a sele\u00E7\u00E3o de arquivo", priority = 1)
+	public void cancelFileSelection() {
+		FileUpload fileUpload = (FileUpload) runner.getElement(FileUpload.class);
+		fileUpload.cancel();
+	}
+	
+	@When(value = "altero o diret\u00F3rio de abertura de arquivo para \"$dir\"", priority = 1)
+	@Then(value = "altero o diret\u00F3rio de abertura de arquivo para \"$dir\"", priority = 1)
+	public void setFileSelectionCurrentDirectory(String dirPath) {
+		FileUpload fileUpload = (FileUpload) runner.getElement(FileUpload.class);
+		fileUpload.setCurrentDirectory(dirPath);
+	}
+	
+	@When(value = "peço para abrir o arquivo \"$file\"", priority = 1)
+	@Then(value = "peço para abrir o arquivo \"$file\"", priority = 1)
+	public void openFile(String fileName) {
+		FileUpload fileUpload = (FileUpload) runner.getElement(FileUpload.class);
+		fileUpload.openFile(fileName);
 	}
 
 }

--- a/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/FestRunner.java
+++ b/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/FestRunner.java
@@ -67,9 +67,11 @@ import br.gov.frameworkdemoiselle.behave.internal.util.ReflectionUtil;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
 import br.gov.frameworkdemoiselle.behave.runner.Runner;
 import br.gov.frameworkdemoiselle.behave.runner.fest.annotation.ElementIndex;
+import br.gov.frameworkdemoiselle.behave.runner.fest.ui.DesktopFileUpload;
 import br.gov.frameworkdemoiselle.behave.runner.fest.util.DesktopElement;
 import br.gov.frameworkdemoiselle.behave.runner.fest.util.DesktopReflectionUtil;
 import br.gov.frameworkdemoiselle.behave.runner.ui.Element;
+import br.gov.frameworkdemoiselle.behave.runner.ui.FileUpload;
 import br.gov.frameworkdemoiselle.behave.runner.ui.Screen;
 
 public class FestRunner implements Runner {
@@ -244,6 +246,19 @@ public class FestRunner implements Runner {
 		element.setElementIndex(index);
 
 		return element;
+	}
+
+	@Override
+	public Element getElement(Class<?> elementClass) {
+		
+		if (elementClass.equals(FileUpload.class)) {
+			return new DesktopFileUpload();
+		} else {
+			BehaveMessage coreMessage = new BehaveMessage(BehaveConfig.MESSAGEBUNDLE);
+			throw new BehaveException(coreMessage.getString("exception-method-not-implemented-for-type"
+					, "FestRunner.getElement(Class<?> elementClass)", elementClass.getSimpleName()));
+		}
+		
 	}
 
 	@Override

--- a/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopFileUpload.java
+++ b/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopFileUpload.java
@@ -1,0 +1,86 @@
+/*
+ * Demoiselle Framework
+ * Copyright (C) 2013 SERPRO
+ * ----------------------------------------------------------------------------
+ * This file is part of Demoiselle Framework.
+ * 
+ * Demoiselle Framework is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License version 3
+ * as published by the Free Software Foundation.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this program; if not,  see <http://www.gnu.org/licenses/>
+ * or write to the Free Software Foundation, Inc., 51 Franklin Street,
+ * Fifth Floor, Boston, MA  02110-1301, USA.
+ * ----------------------------------------------------------------------------
+ * Este arquivo é parte do Framework Demoiselle.
+ * 
+ * O Framework Demoiselle é um software livre; você pode redistribuí-lo e/ou
+ * modificá-lo dentro dos termos da GNU LGPL versão 3 como publicada pela Fundação
+ * do Software Livre (FSF).
+ * 
+ * Este programa é distribuído na esperança que possa ser útil, mas SEM NENHUMA
+ * GARANTIA; sem uma garantia implícita de ADEQUAÇÃO a qualquer MERCADO ou
+ * APLICAÇÃO EM PARTICULAR. Veja a Licença Pública Geral GNU/LGPL em português
+ * para maiores detalhes.
+ * 
+ * Você deve ter recebido uma cópia da GNU LGPL versão 3, sob o título
+ * "LICENCA.txt", junto com esse programa. Se não, acesse <http://www.gnu.org/licenses/>
+ * ou escreva para a Fundação do Software Livre (FSF) Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA 02111-1301, USA.
+ */
+package br.gov.frameworkdemoiselle.behave.runner.fest.ui;
+
+import java.io.File;
+
+import org.fest.swing.finder.JFileChooserFinder;
+import org.fest.swing.fixture.JFileChooserFixture;
+
+import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
+import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.runner.fest.FestRunner;
+import br.gov.frameworkdemoiselle.behave.runner.ui.FileUpload;
+
+/**
+ * 
+ * @author SERPRO
+ *
+ */
+public class DesktopFileUpload extends DesktopBase implements FileUpload {
+	
+	protected BehaveMessage coreMessage = new BehaveMessage(BehaveConfig.MESSAGEBUNDLE);
+
+	@Override
+	public void sendKeys(CharSequence... keysToSend) {
+		// TODO Implement for desktop applications
+		throw new BehaveException(coreMessage.getString("exception-method-not-implemented", "DesktopFileUpload.sendKeys(CharSequence... keysToSend)"));
+	}
+
+	@Override
+	public void cancel() {
+		JFileChooserFixture fileChooser = JFileChooserFinder.findFileChooser().using(((FestRunner) runner).robot);
+		fileChooser.cancel();
+	}
+
+	@Override
+	public void setCurrentDirectory(String dirPath) {
+		File dir = new File(dirPath);
+		JFileChooserFixture fileChooser = JFileChooserFinder.findFileChooser().using(((FestRunner) runner).robot);
+		fileChooser.setCurrentDirectory(dir);
+	}
+
+	@Override
+	public void openFile(String fileName) {
+		File file = new File(fileName);
+		JFileChooserFixture fileChooser = JFileChooserFinder.findFileChooser().using(((FestRunner) runner).robot);
+		fileChooser.selectFile(file);
+		fileChooser.approve();
+	}
+
+}

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/WebDriverRunner.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/WebDriverRunner.java
@@ -161,6 +161,12 @@ public class WebDriverRunner implements Runner {
 		return element;
 	}
 
+	@Override
+	public Element getElement(Class<?> elementClass) {
+		// TODO Implement for web applications
+		throw new BehaveException(message.getString("exception-method-not-implemented", "WebDriverRunner.getElement(Class<?> elementClass)"));		
+	}
+
 	public String getPageSource() {
 		return driver.getPageSource();
 	}

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebFileUpload.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebFileUpload.java
@@ -36,8 +36,11 @@
  */
 package br.gov.frameworkdemoiselle.behave.runner.webdriver.ui;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.openqa.selenium.WebElement;
 
+import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
 import br.gov.frameworkdemoiselle.behave.runner.ui.FileUpload;
 
 /**
@@ -46,10 +49,31 @@ import br.gov.frameworkdemoiselle.behave.runner.ui.FileUpload;
  *
  */
 public class WebFileUpload extends WebBase implements FileUpload {
+	
+	protected BehaveMessage coreMessage = new BehaveMessage(BehaveConfig.MESSAGEBUNDLE);
 
+	@Override
 	public void sendKeys(CharSequence... keysToSend) {
 		WebElement input = this.getElements().get(0);
 		input.sendKeys(keysToSend);
+	}
+
+	@Override
+	public void cancel() {
+		// TODO Implement for web applications
+		throw new NotImplementedException(coreMessage.getString("exception-method-not-implemented", "WebFileUpload.cancel()"));
+	}
+
+	@Override
+	public void setCurrentDirectory(String dirPath) {
+		// TODO Implement for web applications
+		throw new NotImplementedException(coreMessage.getString("exception-method-not-implemented", "WebFileUpload.setCurrentDirectory()"));
+	}
+
+	@Override
+	public void openFile(String fileName) {
+		// TODO Implement for web applications
+		throw new NotImplementedException(coreMessage.getString("exception-method-not-implemented", "WebFileUpload.openFile()"));
 	}
 
 }

--- a/sample/treino-desktop/pom.xml
+++ b/sample/treino-desktop/pom.xml
@@ -45,7 +45,7 @@
 	<parent>
 		<groupId>br.gov.frameworkdemoiselle.component.behave</groupId>
 		<artifactId>demoiselle-behave-parent</artifactId>
-		<version>1.5.3-SNAPSHOT</version>
+		<version>1.5.4-SNAPSHOT</version>
 	</parent>
 
 	<name>Demoiselle Behave Treino Desktop</name>


### PR DESCRIPTION
Para manipulação de janela de seleção de arquivo, foram adicionados os passos:
- "cancelo a seleção de arquivo";
- "altero o diretório de abertura de arquivo para \"$dir\"";
- "peço para abrir o arquivo \"$file\"".

As ações somente foram implementadas para o _runner_ Fest, através do componente _DesktopFileUpload_.