### PR TITLE
Adicionado processo para criação de instâncias únicas dos resources bundles

### DIFF
--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/config/BehaveConfig.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/config/BehaveConfig.java
@@ -45,6 +45,7 @@ import org.apache.log4j.Logger;
 
 import br.gov.frameworkdemoiselle.behave.internal.util.PropertiesLoaderUtil;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 
 /**
  * Gerecia das configurações do Demoiselle Behave. Utiliza o arquivo
@@ -312,7 +313,7 @@ public class BehaveConfig {
 	 */
 	public static void logValueProperties() {
 		if (log.isDebugEnabled()) {
-			BehaveMessage bm = new BehaveMessage(MESSAGEBUNDLE);
+			BehaveMessage bm = BehaveMessageFactory.getInstance().getBehaveMessage(MESSAGEBUNDLE);
 			ArrayList<String> propertieList = new ArrayList<String>();
 			log.debug("------- " + bm.getString("properties") + " ----------");
 			Enumeration<Object> keys = properties.keys();

--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/controller/BehaveContext.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/controller/BehaveContext.java
@@ -50,6 +50,7 @@ import br.gov.frameworkdemoiselle.behave.internal.filter.StoryOrScenarioFilter;
 import br.gov.frameworkdemoiselle.behave.internal.parser.StoryFileConverter;
 import br.gov.frameworkdemoiselle.behave.internal.spi.InjectionManager;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.parser.Parser;
 import br.gov.frameworkdemoiselle.behave.parser.Step;
 
@@ -103,7 +104,7 @@ public class BehaveContext {
 	private BehaveMessage bm;
 
 	private BehaveContext() {
-		bm = new BehaveMessage(BehaveConfig.MESSAGEBUNDLE);
+		bm = BehaveMessageFactory.getInstance().getBehaveMessage(BehaveConfig.MESSAGEBUNDLE);
 	}
 
 	private void checkClassScopeManagerExtension(){

--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/controller/ClassScopeManager.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/controller/ClassScopeManager.java
@@ -5,6 +5,7 @@ import org.junit.AfterClass;
 import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 
 public class ClassScopeManager {
 
@@ -14,7 +15,7 @@ public class ClassScopeManager {
 
 	@AfterClass
 	public static void clearClassLists() {
-		BehaveMessage bm = new BehaveMessage(BehaveConfig.MESSAGEBUNDLE);
+		BehaveMessage bm = BehaveMessageFactory.getInstance().getBehaveMessage(BehaveConfig.MESSAGEBUNDLE);
 		if (!BehaveConfig.getRunner_LegacyRunner()){
 			behaveContext.getStepsClass().clear();
 			behaveContext.getStoriesClass().clear();

--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/dataprovider/DefaultDataProvider.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/dataprovider/DefaultDataProvider.java
@@ -43,6 +43,7 @@ import org.apache.log4j.Logger;
 import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.dataprovider.DataProvider;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 
 /**
  * 
@@ -53,7 +54,7 @@ public class DefaultDataProvider implements DataProvider {
 	
 	private static Hashtable<String, Object> data;
 	private static Logger logger = Logger.getLogger(DefaultDataProvider.class);
-	private static BehaveMessage bm = new BehaveMessage(BehaveConfig.MESSAGEBUNDLE);
+	private static BehaveMessage bm = BehaveMessageFactory.getInstance().getBehaveMessage(BehaveConfig.MESSAGEBUNDLE);
 	
 	public DefaultDataProvider() {
 		data = new Hashtable<String, Object>();

--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/dataprovider/DefaultDatasetProvider.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/dataprovider/DefaultDatasetProvider.java
@@ -12,6 +12,7 @@ import br.gov.frameworkdemoiselle.behave.dataprovider.dto.Dataset;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.internal.spi.InjectionManager;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 
 /**
  * 
@@ -26,7 +27,7 @@ public class DefaultDatasetProvider implements DatasetProvider {
 	
 	private static Hashtable<String, Dataset> dataSets;
 	
-	private static BehaveMessage bm = new BehaveMessage(BehaveConfig.MESSAGEBUNDLE);
+	private static BehaveMessage bm = BehaveMessageFactory.getInstance().getBehaveMessage(BehaveConfig.MESSAGEBUNDLE);
 	
 	public DefaultDatasetProvider() {
 		super();

--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/dataprovider/database/DatabaseDatasetLoader.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/dataprovider/database/DatabaseDatasetLoader.java
@@ -14,6 +14,7 @@ import br.gov.frameworkdemoiselle.behave.dataprovider.dto.Dataset;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.internal.spi.InjectionManager;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 
 /**
  * 
@@ -24,7 +25,7 @@ public class DatabaseDatasetLoader implements DatasetLoader {
 	
 	private static DatabaseConnector databaseConnector = (DatabaseConnector) InjectionManager.getInstance().getInstanceDependecy(DatabaseConnector.class);
 	
-	private static BehaveMessage bm = new BehaveMessage(BehaveConfig.MESSAGEBUNDLE);
+	private static BehaveMessage bm = BehaveMessageFactory.getInstance().getBehaveMessage(BehaveConfig.MESSAGEBUNDLE);
 
 	public Dataset load(String tableName){
 		try {

--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/dataprovider/xml/XStreamXmlLoader.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/dataprovider/xml/XStreamXmlLoader.java
@@ -10,6 +10,7 @@ import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.dataprovider.XmlLoader;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 
 import com.thoughtworks.xstream.XStream;
 
@@ -20,7 +21,7 @@ import com.thoughtworks.xstream.XStream;
  */
 public class XStreamXmlLoader implements XmlLoader {
 
-	private static BehaveMessage bm = new BehaveMessage(BehaveConfig.MESSAGEBUNDLE);
+	private static BehaveMessage bm = BehaveMessageFactory.getInstance().getBehaveMessage(BehaveConfig.MESSAGEBUNDLE);
 	
 	protected XStream xstream = null;
 	

--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/parser/ScenarioParameter.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/parser/ScenarioParameter.java
@@ -47,6 +47,7 @@ import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.internal.util.RegularExpressionUtil;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 
 /**
  * 
@@ -57,7 +58,7 @@ public class ScenarioParameter {
 
 	private static final String PARAMETER_PATTERN = "(\"([^\"]*)\")";
 
-	private static BehaveMessage bm = new BehaveMessage(BehaveConfig.MESSAGEBUNDLE);
+	private static BehaveMessage bm = BehaveMessageFactory.getInstance().getBehaveMessage(BehaveConfig.MESSAGEBUNDLE);
 
 	/**
 	 * Substitui os nome de parâmetro por parâmetros vazios, viabilizando a

--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/parser/StoryConverter.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/parser/StoryConverter.java
@@ -88,6 +88,7 @@ import br.gov.frameworkdemoiselle.behave.internal.filter.StoryOrScenarioFilter;
 import br.gov.frameworkdemoiselle.behave.internal.filter.StoryFilter;
 import br.gov.frameworkdemoiselle.behave.internal.util.RegularExpressionUtil;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 
 /**
  * 
@@ -98,7 +99,7 @@ public class StoryConverter {
 
 	private static final String LINE_BREAK_TOKEN = "\n";
 
-	private static BehaveMessage bm = new BehaveMessage(BehaveConfig.MESSAGEBUNDLE);
+	private static BehaveMessage bm = BehaveMessageFactory.getInstance().getBehaveMessage(BehaveConfig.MESSAGEBUNDLE);
 
 	/*
 	 * Definições: story=arquivo com um ou mais cenários ;

--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/parser/StoryFileConverter.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/parser/StoryFileConverter.java
@@ -46,6 +46,7 @@ import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.internal.util.FileUtil;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 
 /**
  * 
@@ -54,7 +55,7 @@ import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
  */
 public class StoryFileConverter {
 
-	private static BehaveMessage bm = new BehaveMessage(BehaveConfig.MESSAGEBUNDLE);
+	private static BehaveMessage bm = BehaveMessageFactory.getInstance().getBehaveMessage(BehaveConfig.MESSAGEBUNDLE);
 
 	public static List<String> convertReusedScenarios(List<String> originalFolderes, String originalExtension, String convertedExtension, Boolean includeSubFolder) {
 		try {

--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/spi/InjectionManager.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/spi/InjectionManager.java
@@ -45,6 +45,7 @@ import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.internal.ui.UIProxy;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.runner.ui.Element;
 
 /**
@@ -57,7 +58,7 @@ public class InjectionManager {
 
 	private Hashtable<String, Object> singletons = new Hashtable<String, Object>();
 	private static InjectionManager instance;
-	private static BehaveMessage bm = new BehaveMessage(BehaveConfig.MESSAGEBUNDLE);
+	private static BehaveMessage bm = BehaveMessageFactory.getInstance().getBehaveMessage(BehaveConfig.MESSAGEBUNDLE);
 
 	void setSingletons(Hashtable<String, Object> singletons) {
 		this.singletons = singletons;

--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/ui/UIProxy.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/ui/UIProxy.java
@@ -9,12 +9,13 @@ import org.apache.log4j.Logger;
 import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 
 public class UIProxy implements InvocationHandler {
 
 	private Object obj;
 	Logger log = Logger.getLogger(UIProxy.class);
-	private BehaveMessage bm = new BehaveMessage(BehaveConfig.MESSAGEBUNDLE);
+	private BehaveMessage bm = BehaveMessageFactory.getInstance().getBehaveMessage(BehaveConfig.MESSAGEBUNDLE);
 
 	public static Object newInstance(Object obj) {
 		return java.lang.reflect.Proxy.newProxyInstance(obj.getClass().getClassLoader(), obj.getClass().getInterfaces(), new UIProxy(obj));

--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/util/DataProviderUtil.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/util/DataProviderUtil.java
@@ -45,12 +45,13 @@ import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.dataprovider.DataProvider;
 import br.gov.frameworkdemoiselle.behave.internal.spi.InjectionManager;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 
 public class DataProviderUtil {
 	
 	private static DataProvider dataProvider = (DataProvider) InjectionManager.getInstance().getInstanceDependecy(DataProvider.class);
 	private static Logger logger = Logger.getLogger(DataProviderUtil.class);
-	private static BehaveMessage bm = new BehaveMessage(BehaveConfig.MESSAGEBUNDLE);
+	private static BehaveMessage bm = BehaveMessageFactory.getInstance().getBehaveMessage(BehaveConfig.MESSAGEBUNDLE);
 	
 	public static List<String> replaceDataProvider(List<String> valueList){
 		List<String> newValueList = new ArrayList<String>();		

--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/util/FileUtil.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/util/FileUtil.java
@@ -51,6 +51,7 @@ import java.util.List;
 import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 
 /**
  * 
@@ -60,7 +61,7 @@ import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
 public class FileUtil {
 
 	public static final String FILE_SEPARATOR = System.getProperty("file.separator");
-	private static BehaveMessage bm = new BehaveMessage(BehaveConfig.MESSAGEBUNDLE);
+	private static BehaveMessage bm = BehaveMessageFactory.getInstance().getBehaveMessage(BehaveConfig.MESSAGEBUNDLE);
 
 	public static String loadFile(String pFilePath) throws IOException {		
 		pFilePath = pFilePath.replaceAll("%20", " "); // Correção de problemas com espaços		

--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/util/PropertiesLoaderUtil.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/util/PropertiesLoaderUtil.java
@@ -50,6 +50,7 @@ import org.apache.log4j.Logger;
 import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 
 /**
  * 
@@ -62,7 +63,7 @@ public class PropertiesLoaderUtil implements Serializable {
 
 	private static PropertiesLoaderUtil config;
 	private Properties allProps;
-	private static BehaveMessage bm = new BehaveMessage(BehaveConfig.MESSAGEBUNDLE, Locale.getDefault());
+	private static BehaveMessage bm = BehaveMessageFactory.getInstance().getBehaveMessage(BehaveConfig.MESSAGEBUNDLE, Locale.getDefault());
 	
 	private static Logger log = Logger.getLogger(PropertiesLoaderUtil.class);
 

--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/util/ReflectionUtil.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/internal/util/ReflectionUtil.java
@@ -48,6 +48,7 @@ import br.gov.frameworkdemoiselle.behave.annotation.ScreenMap;
 import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 
 /**
  * 
@@ -56,7 +57,7 @@ import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
  */
 public class ReflectionUtil {
 
-	private static BehaveMessage bm = new BehaveMessage(BehaveConfig.MESSAGEBUNDLE);
+	private static BehaveMessage bm = BehaveMessageFactory.getInstance().getBehaveMessage(BehaveConfig.MESSAGEBUNDLE);
 
 	public static String getLocation(String name) {
 		Reflections reflections = new Reflections("");

--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/message/BehaveMessage.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/message/BehaveMessage.java
@@ -41,51 +41,86 @@ import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
-import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 /**
+ * Class that manipulates Demoiselle Behave resource bundles.
  * 
  * @author SERPRO
  *
  */
 public class BehaveMessage {
 
-	private ResourceBundle rb = null;
+	/**
+	 * Messages resource bundle.
+	 */
+	private ResourceBundle resourceBundle = null;
 
 	/**
-	 * Constroi o BehaveMessage a partir do nome do bundle
-	 * @param baseName
+	 * Creates a BehaveMessage according to passed resource bundle base name and locale.
+	 * 
+	 * @param baseName the resource bundle base name
+	 * @param locale the resource bundle locale
 	 */
-	public BehaveMessage(String baseName) {
-		rb = ResourceBundle.getBundle(baseName, new Locale(BehaveConfig.getProperty("behave.message.locale", "pt")));
+	protected BehaveMessage(String baseName, Locale locale) {
+		setResourceBundle(baseName, locale);
 	}
-	
-	public BehaveMessage(String baseName, Locale locale) {
+
+	/**
+	 * Gets the resource bundle.
+	 * 
+	 * @return the resource bundle
+	 */
+	public ResourceBundle getResourceBundle() {
+		return resourceBundle;
+	}
+
+	/**
+	 * Sets the resource bundle base name and locale.
+	 * 
+	 * @param baseName the resource bundle base name
+	 * @param locale the resource bundle locale
+	 */
+	private void setResourceBundle(String baseName, Locale locale) {
+		
 		try {
-			rb = ResourceBundle.getBundle(baseName, locale);
+			resourceBundle = ResourceBundle.getBundle(baseName, locale);
 		} catch (MissingResourceException ex) {	
-			rb = ResourceBundle.getBundle(baseName, new Locale("pt","BR"));
+			resourceBundle = ResourceBundle.getBundle(baseName, new Locale("pt","BR"));
 		}
 	}
 
 	/**
-	 * Obtem a mensagem no bundle
-	 * @param key chave da mensagem
-	 * @param params parametros da mensagem
-	 * @return
+	 * Gets the resource bundle message based on a key and some parameters.
+	 * 
+	 * @param key message key
+	 * @param params message parameteres
+	 * 
+	 * @return resource bundle message
 	 */
 	public String getString(String key, Object... params) {
+		
 		if (params == null || params.length == 0) {
 			return getString(key);
 		} else {
 			return MessageFormat.format(getString(key), params);
 		}
+		
 	}
 	
+	/**
+	 * Gets the resource bundle message based on a key.
+	 * 
+	 * @param key message key
+	 * 
+	 * @return resource bundle message
+	 */
 	public String getString(String key) {
-		if (rb.containsKey(key)) {
-			return rb.getString(key);
+		
+		if (resourceBundle.containsKey(key)) {
+			return resourceBundle.getString(key);
 		} else {
 			return "??{" + key + "}??";
 		}
+		
 	}
+	
 }

--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/message/BehaveMessageFactory.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/message/BehaveMessageFactory.java
@@ -1,0 +1,142 @@
+/*
+ * Demoiselle Framework
+ * Copyright (C) 2013 SERPRO
+ * ----------------------------------------------------------------------------
+ * This file is part of Demoiselle Framework.
+ * 
+ * Demoiselle Framework is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License version 3
+ * as published by the Free Software Foundation.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this program; if not,  see <http://www.gnu.org/licenses/>
+ * or write to the Free Software Foundation, Inc., 51 Franklin Street,
+ * Fifth Floor, Boston, MA  02110-1301, USA.
+ * ----------------------------------------------------------------------------
+ * Este arquivo é parte do Framework Demoiselle.
+ * 
+ * O Framework Demoiselle é um software livre; você pode redistribuí-lo e/ou
+ * modificá-lo dentro dos termos da GNU LGPL versão 3 como publicada pela Fundação
+ * do Software Livre (FSF).
+ * 
+ * Este programa é distribuído na esperança que possa ser útil, mas SEM NENHUMA
+ * GARANTIA; sem uma garantia implícita de ADEQUAÇÃO a qualquer MERCADO ou
+ * APLICAÇÃO EM PARTICULAR. Veja a Licença Pública Geral GNU/LGPL em português
+ * para maiores detalhes.
+ * 
+ * Você deve ter recebido uma cópia da GNU LGPL versão 3, sob o título
+ * "LICENCA.txt", junto com esse programa. Se não, acesse <http://www.gnu.org/licenses/>
+ * ou escreva para a Fundação do Software Livre (FSF) Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA 02111-1301, USA.
+ */
+package br.gov.frameworkdemoiselle.behave.message;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
+
+/**
+ *  Class that creates {@link BehaveMessage BehaveMessage} according to the base name and locale
+ *  of the resource bundle.
+ * 
+ * @author SERPRO
+ *
+ */
+public final class BehaveMessageFactory {
+
+	/**
+	 * Singleton instance of BehaveMessageFactory.
+	 */
+	private static BehaveMessageFactory instance;
+	
+	/**
+	 * List of already created BehaveMessage.
+	 */
+	private List<BehaveMessage> behaveMessages;
+	
+	/**
+	 * Default constructor.
+	 * Initiates the list of already created BehaveMessage. 
+	 */
+	private BehaveMessageFactory() {
+		behaveMessages = new ArrayList<BehaveMessage>();
+	}
+	
+	/**
+	 * Gets the single instance of BehaveMessageFactory.
+	 * 
+	 * @return the single instance of BehaveMessageFactory.
+	 */
+	synchronized public static BehaveMessageFactory getInstance() {
+		
+		if (instance != null) {
+			return instance;
+		} else {
+			instance = new BehaveMessageFactory();
+			return instance;
+		}
+		
+	}
+	
+	/**
+	 * Gets the instance of BehaveMessage according to the resource bundle base name.
+	 * 
+	 * @param baseName the resource bundle base name
+	 * 
+	 * @return instance of BehaveMessage
+	 */
+	public BehaveMessage getBehaveMessage(String baseName){
+		Locale locale = new Locale(BehaveConfig.getProperty("behave.message.locale", "pt"));
+				
+		return getBehaveMessage(baseName, locale);
+	}
+	
+	/**
+	 * Gets the instance of BehaveMessage according to the resource bundle base name and locale.
+	 * 
+	 * @param baseName the resource bundle base name
+	 * @param locale the resource bundle locale
+	 * 
+	 * @return instance of BehaveMessage
+	 */
+	public BehaveMessage getBehaveMessage(String baseName, Locale locale){		
+		BehaveMessage behaveMessage = findBehaveMessage(baseName, locale);
+		
+		if (behaveMessage == null) {
+			behaveMessage = new BehaveMessage(baseName, locale);
+			behaveMessages.add(behaveMessage);
+		}
+		
+		return behaveMessage;
+	}
+	
+	/**
+	 * Finds a BehaveMessage based on its resource bundle base name and locale.
+	 * 
+	 * @param baseName the resource bundle base name
+	 * @param locale the resource bundle locale
+	 * 
+	 * @return instance of BehaveMessage
+	 */
+	private BehaveMessage findBehaveMessage(String baseName, Locale locale){
+		
+		for (BehaveMessage behaveMessage : behaveMessages) {
+			String objBundleName = behaveMessage.getResourceBundle().getBaseBundleName();
+			Locale objBundleLocale = behaveMessage.getResourceBundle().getLocale(); 	
+			
+			if (objBundleName.equals(baseName) && objBundleLocale.equals(locale)) {
+				return behaveMessage;
+			}
+		}
+		
+		return null;
+	}
+	
+}

--- a/impl/core/src/test/java/br/gov/frameworkdemoiselle/behave/message/BehaveMessageTest.java
+++ b/impl/core/src/test/java/br/gov/frameworkdemoiselle/behave/message/BehaveMessageTest.java
@@ -51,12 +51,12 @@ public class BehaveMessageTest {
 	public void testGetStringByLocale() {
 		System.setProperty("behave.message.locale", "pt");
 
-		BehaveMessage message = new BehaveMessage("demoiselle-behave-core-bundle");
+		BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage("demoiselle-behave-core-bundle");
 		assertEquals("message-exception-001-pt", message.getString("exception-001"));
 
 		System.setProperty("behave.message.locale", "en");
 
-		message = new BehaveMessage("demoiselle-behave-core-bundle");
+		message = BehaveMessageFactory.getInstance().getBehaveMessage("demoiselle-behave-core-bundle");
 		assertEquals("message-exception-001-en", message.getString("exception-001"));
 	}
 
@@ -64,18 +64,18 @@ public class BehaveMessageTest {
 	public void testGetStringParans() {
 		System.setProperty("behave.message.locale", "pt");
 
-		BehaveMessage message = new BehaveMessage("demoiselle-behave-core-bundle");
+		BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage("demoiselle-behave-core-bundle");
 		assertEquals("message pt: [demoiselle behave]", message.getString("message-param", "demoiselle", "behave"));
 
 		System.setProperty("behave.message.locale", "en");
 
-		message = new BehaveMessage("demoiselle-behave-core-bundle");
+		message = BehaveMessageFactory.getInstance().getBehaveMessage("demoiselle-behave-core-bundle");
 		assertEquals("message en: [demoiselle behave]", message.getString("message-param", "demoiselle", "behave"));
 	}
 	
 	@Test
 	public void testGetStringNotFound() {
-		BehaveMessage message = new BehaveMessage("demoiselle-behave-core-bundle");
+		BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage("demoiselle-behave-core-bundle");
 		assertEquals("??{mykey}??", message.getString("mykey"));
 	}
 

--- a/impl/extension/regression/repository/src/main/java/br/gov/frameworkdemoiselle/behave/regression/repository/AbstractRepository.java
+++ b/impl/extension/regression/repository/src/main/java/br/gov/frameworkdemoiselle/behave/regression/repository/AbstractRepository.java
@@ -41,6 +41,7 @@ import java.io.File;
 import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.regression.Repository;
 
 /**
@@ -61,7 +62,7 @@ public abstract class AbstractRepository implements Repository {
 	protected String password;
 
 	public AbstractRepository() {
-		message = new BehaveMessage(MESSAGEBUNDLE);
+		message = BehaveMessageFactory.getInstance().getBehaveMessage(MESSAGEBUNDLE);
 		url = getProperty("behave.regression.url");		
 		folder = getProperty("behave.regression.folder");
 		user = getProperty("behave.regression.user");

--- a/impl/extension/regression/repository/src/main/java/br/gov/frameworkdemoiselle/behave/regression/repository/FactoryRepository.java
+++ b/impl/extension/regression/repository/src/main/java/br/gov/frameworkdemoiselle/behave/regression/repository/FactoryRepository.java
@@ -39,12 +39,13 @@ package br.gov.frameworkdemoiselle.behave.regression.repository;
 import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.regression.Repository;
 
 public class FactoryRepository {
 
 	public static String MESSAGEBUNDLE = "demoiselle-regression-repository-bundle";
-	private static BehaveMessage message = new BehaveMessage(FactoryRepository.MESSAGEBUNDLE);
+	private static BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(FactoryRepository.MESSAGEBUNDLE);
 	
 	public static Repository getInstance() {
 		String type = BehaveConfig.getProperty("behave.regression.type");

--- a/impl/integration/alm/src/main/java/br/gov/frameworkdemoiselle/behave/integration/alm/ALMIntegration.java
+++ b/impl/integration/alm/src/main/java/br/gov/frameworkdemoiselle/behave/integration/alm/ALMIntegration.java
@@ -73,6 +73,7 @@ import br.gov.frameworkdemoiselle.behave.integration.alm.httpsclient.HttpsClient
 import br.gov.frameworkdemoiselle.behave.integration.alm.objects.util.GenerateXMLString;
 import br.gov.frameworkdemoiselle.behave.internal.integration.ScenarioState;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 
 import com.ibm.rqm.xml.bind.Testcase;
 import com.ibm.rqm.xml.bind.Testplan;
@@ -84,7 +85,7 @@ public class ALMIntegration implements Integration {
 
 	public static String MESSAGEBUNDLE = "demoiselle-integration-alm-bundle";
 
-	private BehaveMessage message = new BehaveMessage(MESSAGEBUNDLE);
+	private BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(MESSAGEBUNDLE);
 
 	public String urlServer;
 	public String urlServerAuth;

--- a/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/BeforeAfterSteps.java
+++ b/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/BeforeAfterSteps.java
@@ -42,6 +42,7 @@ import org.jbehave.core.annotations.BeforeStories;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.internal.spi.InjectionManager;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.parser.Step;
 import br.gov.frameworkdemoiselle.behave.runner.Runner;
 
@@ -49,7 +50,7 @@ public class BeforeAfterSteps implements Step {
 
 	private Runner runner = (Runner) InjectionManager.getInstance().getInstanceDependecy(Runner.class);
 	private Logger logger = Logger.getLogger(BeforeAfterSteps.class);
-	private static BehaveMessage message = new BehaveMessage(JBehaveParser.MESSAGEBUNDLE);
+	private static BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(JBehaveParser.MESSAGEBUNDLE);
 
 	@BeforeStories
 	public void startStories() {

--- a/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/CommonSteps.java
+++ b/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/CommonSteps.java
@@ -51,6 +51,7 @@ import br.gov.frameworkdemoiselle.behave.internal.spi.InjectionManager;
 import br.gov.frameworkdemoiselle.behave.internal.util.DataProviderUtil;
 import br.gov.frameworkdemoiselle.behave.internal.util.ReflectionUtil;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.parser.Step;
 import br.gov.frameworkdemoiselle.behave.runner.Runner;
 import br.gov.frameworkdemoiselle.behave.runner.ui.AutoComplete;
@@ -80,7 +81,7 @@ public class CommonSteps implements Step {
 	protected DatasetProvider datasetProvider = (DatasetProvider) InjectionManager.getInstance().getInstanceDependecy(DatasetProvider.class);
 	private Logger logger = Logger.getLogger(CommonSteps.class);
 	protected static String currentPageName;
-	protected static BehaveMessage message = new BehaveMessage(JBehaveParser.MESSAGEBUNDLE);
+	protected static BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(JBehaveParser.MESSAGEBUNDLE);
 
 	@Given(value = "vou para a tela \"$local\"", priority = 1)
 	@Then(value = "vou para a tela \"$local\"", priority = 1)

--- a/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/JBehaveParser.java
+++ b/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/JBehaveParser.java
@@ -70,6 +70,7 @@ import br.gov.frameworkdemoiselle.behave.controller.BehaveContext;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.internal.util.FileUtil;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.parser.Parser;
 import br.gov.frameworkdemoiselle.behave.parser.Step;
 import br.gov.frameworkdemoiselle.behave.parser.jbehave.converter.MapConverter;
@@ -84,7 +85,7 @@ public class JBehaveParser extends ConfigurableEmbedder implements Parser {
 	private Configuration configuration;
 
 	public static String MESSAGEBUNDLE = "demoiselle-parser-jbehave-bundle";
-	private static BehaveMessage message = new BehaveMessage(JBehaveParser.MESSAGEBUNDLE);
+	private static BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(JBehaveParser.MESSAGEBUNDLE);
 
 	private List<String> storyPaths = new ArrayList<String>();
 	private List<Step> steps = new ArrayList<Step>();

--- a/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/TableSteps.java
+++ b/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/TableSteps.java
@@ -45,12 +45,13 @@ import org.jbehave.core.annotations.When;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.internal.util.DataProviderUtil;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.runner.ui.Element;
 import br.gov.frameworkdemoiselle.behave.runner.ui.Grid;
 
 public class TableSteps extends CommonSteps {
 
-	private static BehaveMessage message = new BehaveMessage(JBehaveParser.MESSAGEBUNDLE);
+	private static BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(JBehaveParser.MESSAGEBUNDLE);
 
 	@Then("clico na linha da tabela \"$table\" referente a \"$reference\"")
 	@When("clico na linha da tabela \"$table\" referente a \"$reference\"")

--- a/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/converter/MapConverter.java
+++ b/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/converter/MapConverter.java
@@ -45,6 +45,7 @@ import org.jbehave.core.steps.ParameterConverters.ParameterConverter;
 
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.parser.jbehave.JBehaveParser;
 
 /**
@@ -54,7 +55,7 @@ import br.gov.frameworkdemoiselle.behave.parser.jbehave.JBehaveParser;
  */
 public class MapConverter implements ParameterConverter {
 
-	private static BehaveMessage message = new BehaveMessage(JBehaveParser.MESSAGEBUNDLE);
+	private static BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(JBehaveParser.MESSAGEBUNDLE);
 	private static final String REGEX = "\\s*?(([\\w\\S]{1,}\\s*?=>\\s*?[\\w\\S]*|\".*?\")[\\s,]*?)*\\s*?";
 
 	public boolean accept(Type type) {

--- a/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/report/ALMStoryReport.java
+++ b/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/report/ALMStoryReport.java
@@ -53,11 +53,12 @@ import br.gov.frameworkdemoiselle.behave.integration.Integration;
 import br.gov.frameworkdemoiselle.behave.internal.integration.ScenarioState;
 import br.gov.frameworkdemoiselle.behave.internal.spi.InjectionManager;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.parser.jbehave.JBehaveParser;
 
 public class ALMStoryReport extends DefaultStoryReport {
 
-	private static BehaveMessage message = new BehaveMessage(JBehaveParser.MESSAGEBUNDLE);
+	private static BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(JBehaveParser.MESSAGEBUNDLE);
 	private Logger log = Logger.getLogger(ALMStoryReport.class);
 	private Story story;
 	private String currentScenarioTitle;

--- a/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/report/ALMTemplateProcessor.java
+++ b/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/report/ALMTemplateProcessor.java
@@ -44,11 +44,12 @@ import org.jbehave.core.reporters.PostStoryStatisticsCollector;
 import org.jbehave.core.reporters.TemplateProcessor;
 
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.parser.jbehave.JBehaveParser;
 
 public class ALMTemplateProcessor implements TemplateProcessor {
 
-	private static BehaveMessage message = new BehaveMessage(JBehaveParser.MESSAGEBUNDLE);
+	private static BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(JBehaveParser.MESSAGEBUNDLE);
 	private Logger log = Logger.getLogger(ALMTemplateProcessor.class);
 
 	public ALMTemplateProcessor() {

--- a/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/report/DefaultStoryReport.java
+++ b/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/report/DefaultStoryReport.java
@@ -55,11 +55,12 @@ import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.controller.BehaveContext;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.parser.jbehave.JBehaveParser;
 
 public class DefaultStoryReport implements StoryReporter {
 
-	private static BehaveMessage message = new BehaveMessage(JBehaveParser.MESSAGEBUNDLE);
+	private static BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(JBehaveParser.MESSAGEBUNDLE);
 	private Logger log = Logger.getLogger(DefaultStoryReport.class);
 
 	public void storyNotAllowed(Story story, String filter) {

--- a/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/report/html/ScreenShootingHtmlOutput.java
+++ b/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/report/html/ScreenShootingHtmlOutput.java
@@ -48,12 +48,13 @@ import org.jbehave.core.reporters.StoryReporterBuilder;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.internal.spi.InjectionManager;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.parser.jbehave.JBehaveParser;
 import br.gov.frameworkdemoiselle.behave.runner.Runner;
 
 public class ScreenShootingHtmlOutput extends HtmlOutput {
 
-	private static BehaveMessage message = new BehaveMessage(JBehaveParser.MESSAGEBUNDLE);
+	private static BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(JBehaveParser.MESSAGEBUNDLE);
 	private ScreenShootingMaker maker;
 	private static final Logger logger = Logger.getLogger(ScreenShootingHtmlOutput.class);
 

--- a/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/report/html/ScreenShootingMaker.java
+++ b/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/report/html/ScreenShootingMaker.java
@@ -50,6 +50,7 @@ import br.gov.frameworkdemoiselle.behave.controller.BehaveContext;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.internal.spi.InjectionManager;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.parser.jbehave.JBehaveParser;
 import br.gov.frameworkdemoiselle.behave.runner.Runner;
 
@@ -58,7 +59,7 @@ public class ScreenShootingMaker {
 	private static final String DEFAULT_SCREENSHOT_PATH_PATTERN = "{0}" + File.separator + "view" + File.separator + "screenshots" + File.separator + "failed-scenario-{1}.png";
 	private static final String DEFAULT_SCREENSHOT_PATH_PATTERN_WITH_SCENARIO = "{0}" + File.separator + "view" + File.separator + "screenshots-with-scenario" + File.separator + "failed-scenario-{1}-{2}.png";
 	private static final Logger logger = Logger.getLogger(ScreenShootingMaker.class);
-	private static BehaveMessage message = new BehaveMessage(JBehaveParser.MESSAGEBUNDLE);
+	private static BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(JBehaveParser.MESSAGEBUNDLE);
 
 	protected final StoryReporterBuilder reporterBuilder;
 	protected final String screenshotPathPattern;

--- a/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/FestRunner.java
+++ b/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/FestRunner.java
@@ -65,6 +65,7 @@ import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.internal.spi.InjectionManager;
 import br.gov.frameworkdemoiselle.behave.internal.util.ReflectionUtil;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.runner.Runner;
 import br.gov.frameworkdemoiselle.behave.runner.fest.annotation.ElementIndex;
 import br.gov.frameworkdemoiselle.behave.runner.fest.ui.DesktopFileUpload;
@@ -79,7 +80,7 @@ public class FestRunner implements Runner {
 	public static String MESSAGEBUNDLE = "demoiselle-runner-fest-bundle";
 	private Logger logger = Logger.getLogger(this.toString());
 
-	private BehaveMessage message = new BehaveMessage(MESSAGEBUNDLE);
+	private BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(MESSAGEBUNDLE);
 
 	public Robot robot;
 	public JFrame mainFrame;
@@ -254,7 +255,7 @@ public class FestRunner implements Runner {
 		if (elementClass.equals(FileUpload.class)) {
 			return new DesktopFileUpload();
 		} else {
-			BehaveMessage coreMessage = new BehaveMessage(BehaveConfig.MESSAGEBUNDLE);
+			BehaveMessage coreMessage = BehaveMessageFactory.getInstance().getBehaveMessage(BehaveConfig.MESSAGEBUNDLE);
 			throw new BehaveException(coreMessage.getString("exception-method-not-implemented-for-type"
 					, "FestRunner.getElement(Class<?> elementClass)", elementClass.getSimpleName()));
 		}

--- a/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopBase.java
+++ b/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopBase.java
@@ -67,13 +67,14 @@ import br.gov.frameworkdemoiselle.behave.annotation.ElementLocatorType;
 import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.runner.fest.FestRunner;
 import br.gov.frameworkdemoiselle.behave.runner.fest.util.DesktopMappedElement;
 import br.gov.frameworkdemoiselle.behave.runner.ui.BaseUI;
 
 public class DesktopBase extends DesktopMappedElement implements BaseUI {
 
-	protected BehaveMessage message = new BehaveMessage(FestRunner.MESSAGEBUNDLE);
+	protected BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(FestRunner.MESSAGEBUNDLE);
 	private Logger log = Logger.getLogger(DesktopBase.class);
 	protected FestRunner runner = (FestRunner) getRunner();
 

--- a/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopFileUpload.java
+++ b/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopFileUpload.java
@@ -44,6 +44,7 @@ import org.fest.swing.fixture.JFileChooserFixture;
 import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.runner.fest.FestRunner;
 import br.gov.frameworkdemoiselle.behave.runner.ui.FileUpload;
 
@@ -54,7 +55,7 @@ import br.gov.frameworkdemoiselle.behave.runner.ui.FileUpload;
  */
 public class DesktopFileUpload extends DesktopBase implements FileUpload {
 	
-	protected BehaveMessage coreMessage = new BehaveMessage(BehaveConfig.MESSAGEBUNDLE);
+	protected BehaveMessage coreMessage = BehaveMessageFactory.getInstance().getBehaveMessage(BehaveConfig.MESSAGEBUNDLE);
 
 	@Override
 	public void sendKeys(CharSequence... keysToSend) {

--- a/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopLabel.java
+++ b/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopLabel.java
@@ -46,12 +46,13 @@ import org.junit.Assert;
 import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.runner.fest.FestRunner;
 import br.gov.frameworkdemoiselle.behave.runner.ui.Label;
 
 public class DesktopLabel extends DesktopBase implements Label {
 
-	private static BehaveMessage message = new BehaveMessage(FestRunner.MESSAGEBUNDLE);
+	private static BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(FestRunner.MESSAGEBUNDLE);
 
 	@Override
 	public String getText() {

--- a/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopScreen.java
+++ b/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopScreen.java
@@ -41,13 +41,14 @@ import java.util.GregorianCalendar;
 import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.runner.fest.FestRunner;
 import br.gov.frameworkdemoiselle.behave.runner.ui.Screen;
 import junit.framework.Assert;
 
 public class DesktopScreen extends DesktopBase implements Screen {
 
-	private BehaveMessage message = new BehaveMessage(FestRunner.MESSAGEBUNDLE);
+	private BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(FestRunner.MESSAGEBUNDLE);
 
 	public void waitText(String text) {
 		waitText(text, 0L);

--- a/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopSelect.java
+++ b/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopSelect.java
@@ -43,11 +43,12 @@ import org.fest.swing.fixture.JComboBoxFixture;
 
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.runner.fest.FestRunner;
 import br.gov.frameworkdemoiselle.behave.runner.ui.Select;
 
 public class DesktopSelect extends DesktopBase implements Select {
-	private static BehaveMessage message = new BehaveMessage(FestRunner.MESSAGEBUNDLE);
+	private static BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(FestRunner.MESSAGEBUNDLE);
 
 	@Override
 	public void isVisibleDisabled() {

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/WebDriverRunner.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/WebDriverRunner.java
@@ -63,6 +63,7 @@ import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.internal.spi.InjectionManager;
 import br.gov.frameworkdemoiselle.behave.internal.util.ReflectionUtil;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.runner.Runner;
 import br.gov.frameworkdemoiselle.behave.runner.ui.Element;
 import br.gov.frameworkdemoiselle.behave.runner.ui.Screen;
@@ -74,7 +75,7 @@ public class WebDriverRunner implements Runner {
 	private WebDriver driver;
 	private WebBrowser browser;
 	public static String MESSAGEBUNDLE = "demoiselle-runner-webdriver-bundle";
-	private static BehaveMessage message = new BehaveMessage(WebDriverRunner.MESSAGEBUNDLE);
+	private static BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(WebDriverRunner.MESSAGEBUNDLE);
 
 	void setWebDriver(WebDriver driver) {
 		this.driver = driver;

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebAutoComplete.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebAutoComplete.java
@@ -47,6 +47,7 @@ import org.openqa.selenium.WebElement;
 import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.runner.ui.AutoComplete;
 import br.gov.frameworkdemoiselle.behave.runner.webdriver.WebDriverRunner;
 
@@ -55,7 +56,7 @@ import br.gov.frameworkdemoiselle.behave.runner.webdriver.WebDriverRunner;
  */
 public class WebAutoComplete extends WebBase implements AutoComplete {
 
-	protected static BehaveMessage message = new BehaveMessage(WebDriverRunner.MESSAGEBUNDLE);
+	protected static BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(WebDriverRunner.MESSAGEBUNDLE);
 
 	/**
 	 * Armazena o valor que será selecionado na lista do autocomplete, somente

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebBase.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebBase.java
@@ -62,6 +62,7 @@ import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.internal.ui.MappedElement;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.runner.ui.BaseUI;
 import br.gov.frameworkdemoiselle.behave.runner.ui.Loading;
 import br.gov.frameworkdemoiselle.behave.runner.webdriver.WebDriverRunner;
@@ -71,7 +72,7 @@ import br.gov.frameworkdemoiselle.behave.runner.webdriver.util.SwitchDriver;
 public class WebBase extends MappedElement implements BaseUI {
 
 	private List<String> locatorParameters;
-	private static BehaveMessage message = new BehaveMessage(WebDriverRunner.MESSAGEBUNDLE);
+	private static BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(WebDriverRunner.MESSAGEBUNDLE);
 	private SwitchDriver frame;
 	Logger log = Logger.getLogger(WebBase.class);
 

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebFileUpload.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebFileUpload.java
@@ -41,6 +41,7 @@ import org.openqa.selenium.WebElement;
 
 import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.runner.ui.FileUpload;
 
 /**
@@ -50,7 +51,7 @@ import br.gov.frameworkdemoiselle.behave.runner.ui.FileUpload;
  */
 public class WebFileUpload extends WebBase implements FileUpload {
 	
-	protected BehaveMessage coreMessage = new BehaveMessage(BehaveConfig.MESSAGEBUNDLE);
+	protected BehaveMessage coreMessage = BehaveMessageFactory.getInstance().getBehaveMessage(BehaveConfig.MESSAGEBUNDLE);
 
 	@Override
 	public void sendKeys(CharSequence... keysToSend) {

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebImage.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebImage.java
@@ -43,12 +43,13 @@ import org.openqa.selenium.WebElement;
 
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.runner.ui.Image;
 import br.gov.frameworkdemoiselle.behave.runner.webdriver.WebDriverRunner;
 
 public class WebImage extends WebBase implements Image {
 	
-	protected static BehaveMessage message = new BehaveMessage(WebDriverRunner.MESSAGEBUNDLE);
+	protected static BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(WebDriverRunner.MESSAGEBUNDLE);
 	
 	/**
 	 * {@inheritDoc}

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebTextField.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebTextField.java
@@ -47,13 +47,14 @@ import org.openqa.selenium.interactions.Actions;
 import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.runner.ui.TextField;
 import br.gov.frameworkdemoiselle.behave.runner.webdriver.WebDriverRunner;
 
 
 public class WebTextField extends WebBase implements TextField {
 
-	private static BehaveMessage message = new BehaveMessage(WebDriverRunner.MESSAGEBUNDLE);
+	private static BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(WebDriverRunner.MESSAGEBUNDLE);
 
 	public void sendKeys(CharSequence... keysToSend) {
 		waitElement(0);

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/richfaces4/RichCalendar.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/richfaces4/RichCalendar.java
@@ -38,6 +38,7 @@ package br.gov.frameworkdemoiselle.behave.runner.webdriver.ui.richfaces4;
 
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.runner.ui.Calendar;
 import br.gov.frameworkdemoiselle.behave.runner.webdriver.WebDriverRunner;
 import br.gov.frameworkdemoiselle.behave.runner.webdriver.ui.WebBase;
@@ -57,7 +58,7 @@ import br.gov.frameworkdemoiselle.behave.runner.webdriver.ui.WebBase;
  */
 public class RichCalendar extends WebBase implements Calendar {
 
-	private static BehaveMessage message = new BehaveMessage(WebDriverRunner.MESSAGEBUNDLE);
+	private static BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(WebDriverRunner.MESSAGEBUNDLE);
 
 	/*
 	 * (non-Javadoc)

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/richfaces4/RichFileUpload.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/richfaces4/RichFileUpload.java
@@ -41,6 +41,7 @@ import org.openqa.selenium.WebElement;
 import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.runner.webdriver.WebDriverRunner;
 import br.gov.frameworkdemoiselle.behave.runner.webdriver.ui.WebBase;
 
@@ -57,7 +58,7 @@ import br.gov.frameworkdemoiselle.behave.runner.webdriver.ui.WebBase;
  */
 public class RichFileUpload extends WebBase {
 
-	private static BehaveMessage message = new BehaveMessage(WebDriverRunner.MESSAGEBUNDLE);
+	private static BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(WebDriverRunner.MESSAGEBUNDLE);
 	
 	public void sendKeys(CharSequence... keysToSend) {
 		checkRichfacesComponent();

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/richfaces4/RichInputNumberSpinner.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/richfaces4/RichInputNumberSpinner.java
@@ -40,6 +40,7 @@ import org.openqa.selenium.WebElement;
 
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.runner.webdriver.WebDriverRunner;
 import br.gov.frameworkdemoiselle.behave.runner.webdriver.ui.WebBase;
 
@@ -56,7 +57,7 @@ import br.gov.frameworkdemoiselle.behave.runner.webdriver.ui.WebBase;
  */
 public class RichInputNumberSpinner extends WebBase {
 
-	private static BehaveMessage message = new BehaveMessage(WebDriverRunner.MESSAGEBUNDLE);
+	private static BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(WebDriverRunner.MESSAGEBUNDLE);
 	
 	public void sendKeys(CharSequence... keysToSend) {
 		checkRichfacesComponent();

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/richfaces4/RichSelect.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/richfaces4/RichSelect.java
@@ -38,6 +38,7 @@ package br.gov.frameworkdemoiselle.behave.runner.webdriver.ui.richfaces4;
 
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.runner.ui.Select;
 import br.gov.frameworkdemoiselle.behave.runner.webdriver.WebDriverRunner;
 import br.gov.frameworkdemoiselle.behave.runner.webdriver.ui.WebBase;
@@ -56,7 +57,7 @@ import br.gov.frameworkdemoiselle.behave.runner.webdriver.ui.WebBase;
  */
 public class RichSelect extends WebBase implements Select {
 
-	private static BehaveMessage message = new BehaveMessage(WebDriverRunner.MESSAGEBUNDLE);
+	private static BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(WebDriverRunner.MESSAGEBUNDLE);
 
 	/**
 	 * Clica no campo do rich:select, provocando a abertura ou o fechamento do

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/util/ByConverter.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/util/ByConverter.java
@@ -41,11 +41,12 @@ import org.openqa.selenium.By;
 import br.gov.frameworkdemoiselle.behave.annotation.ElementLocatorType;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.runner.webdriver.WebDriverRunner;
 
 public class ByConverter {
 
-	private static BehaveMessage message = new BehaveMessage(WebDriverRunner.MESSAGEBUNDLE);
+	private static BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(WebDriverRunner.MESSAGEBUNDLE);
 
 	public static By convert(ElementLocatorType type, String locator) {
 		By by = null;

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/util/WebBrowser.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/util/WebBrowser.java
@@ -59,6 +59,7 @@ import org.openqa.selenium.safari.SafariDriver;
 import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
 import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
 import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessageFactory;
 import br.gov.frameworkdemoiselle.behave.runner.webdriver.WebDriverRunner;
 
 public enum WebBrowser {
@@ -71,7 +72,7 @@ public enum WebBrowser {
 
 		@Override
 		public WebDriver getWebDriver() {
-			BehaveMessage message = new BehaveMessage(WebDriverRunner.MESSAGEBUNDLE);
+			BehaveMessage message = BehaveMessageFactory.getInstance().getBehaveMessage(WebDriverRunner.MESSAGEBUNDLE);
 			try {
 				if (BehaveConfig.getRunner_RemoteName().equals("")) {
 					throw new BehaveException(message.getString("exception-property-not-found", "behave.runner.screen.remote.name"));


### PR DESCRIPTION
Atualmente há vários locais nos quais se criam instâncias de _BehaveMessage_, com isso,  podem haver _N_ instâncias de um mesmo _resource bundle_, o que gera gasto desnecessário de recurso computacional, mesmo que pequeno.

Então, foi construída a classe _BehaveMessageFactory_ para centralizar a instanciação dos _resource bundles_, fazendo o controle para existir apenas um _resource bundles_ instanciado de cada tipo.

A classe _BehaveMessage_ foi alterada para não ser mais possível sua instanciação pelo seu construtor.

Todo o código foi revisado e todas as chamadas a _new BehaveMessageFactory(...)_ foram alteradas para chamadas a _BehaveMessageFactory.getInstance().getBehaveMessage(...)_.