### PR TITLE
Adicionado tratamento de caixas de diálogo para o Fest

### DIFF
--- a/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/runner/ui/Dialog.java
+++ b/impl/core/src/main/java/br/gov/frameworkdemoiselle/behave/runner/ui/Dialog.java
@@ -45,6 +45,8 @@ package br.gov.frameworkdemoiselle.behave.runner.ui;
 public interface Dialog extends BaseUI {
 
 	public void accept();
+
+	public void accept(String buttonText, String dialogTitle);
 	
 	public void cancel();
 	

--- a/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/DialogSteps.java
+++ b/impl/parser/jbehave/src/main/java/br/gov/frameworkdemoiselle/behave/parser/jbehave/DialogSteps.java
@@ -57,6 +57,14 @@ public class DialogSteps extends CommonSteps {
 		dialog.accept();
 	}
 
+	@When("clico no bot\u00E3o \"$buttonText\" da caixa de di\u00E1logo de t\u00EDtulo \"$dialogTitle\"")
+	@Given("clico no bot\u00E3o \"$buttonText\" da caixa de di\u00E1logo de t\u00EDtulo \"$dialogTitle\"")
+	@Then("clico no bot\u00E3o \"$buttonText\" da caixa de di\u00E1logo de t\u00EDtulo \"$dialogTitle\"")
+	public void acceptDialog(String buttonText, String dialogTitle) {
+		Dialog dialog = (Dialog) InjectionManager.getInstance().getInstanceDependecy(Dialog.class);
+		dialog.accept(buttonText, dialogTitle);
+	}
+
 	@When("cancelo a caixa de di\u00E1logo")
 	@Given("cancelo a caixa de di\u00E1logo")
 	@Then("cancelo a caixa de di\u00E1logo")

--- a/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopDialog.java
+++ b/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopDialog.java
@@ -1,0 +1,215 @@
+/*
+ * Demoiselle Framework
+ * Copyright (C) 2013 SERPRO
+ * ----------------------------------------------------------------------------
+ * This file is part of Demoiselle Framework.
+ * 
+ * Demoiselle Framework is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License version 3
+ * as published by the Free Software Foundation.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this program; if not,  see <http://www.gnu.org/licenses/>
+ * or write to the Free Software Foundation, Inc., 51 Franklin Street,
+ * Fifth Floor, Boston, MA  02110-1301, USA.
+ * ----------------------------------------------------------------------------
+ * Este arquivo é parte do Framework Demoiselle.
+ * 
+ * O Framework Demoiselle é um software livre; você pode redistribuí-lo e/ou
+ * modificá-lo dentro dos termos da GNU LGPL versão 3 como publicada pela Fundação
+ * do Software Livre (FSF).
+ * 
+ * Este programa é distribuído na esperança que possa ser útil, mas SEM NENHUMA
+ * GARANTIA; sem uma garantia implícita de ADEQUAÇÃO a qualquer MERCADO ou
+ * APLICAÇÃO EM PARTICULAR. Veja a Licença Pública Geral GNU/LGPL em português
+ * para maiores detalhes.
+ * 
+ * Você deve ter recebido uma cópia da GNU LGPL versão 3, sob o título
+ * "LICENCA.txt", junto com esse programa. Se não, acesse <http://www.gnu.org/licenses/>
+ * ou escreva para a Fundação do Software Livre (FSF) Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA 02111-1301, USA.
+ */
+package br.gov.frameworkdemoiselle.behave.runner.fest.ui;
+
+import static org.fest.swing.edt.GuiActionRunner.execute;
+import static org.fest.util.Strings.concat;
+import static org.fest.util.Strings.quote;
+
+import java.awt.Component;
+import java.awt.Container;
+import java.util.ArrayList;
+
+import javax.swing.JButton;
+import javax.swing.JDialog;
+
+import org.fest.swing.annotation.RunsInEDT;
+import org.fest.swing.core.GenericTypeMatcher;
+import org.fest.swing.edt.GuiQuery;
+import org.fest.swing.finder.DialogFinder;
+import org.fest.swing.finder.WindowFinder;
+import org.fest.swing.fixture.DialogFixture;
+
+import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
+import br.gov.frameworkdemoiselle.behave.exception.BehaveException;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
+import br.gov.frameworkdemoiselle.behave.runner.fest.FestRunner;
+import br.gov.frameworkdemoiselle.behave.runner.ui.Dialog;
+
+public class DesktopDialog extends DesktopBase implements Dialog {
+
+	protected BehaveMessage coreMessage = new BehaveMessage(BehaveConfig.MESSAGEBUNDLE);
+
+	@Override
+	public void accept() {
+		DialogFinder dialogFinder = WindowFinder.findDialog(JDialog.class);
+		DialogFixture dialogFixture = dialogFinder.using(((FestRunner) runner).robot);
+		java.awt.Dialog dialog = dialogFixture.component();
+		JButton button = getDialogButton(dialog);
+		button.doClick();
+	}
+
+	@Override
+	public void accept(String buttonText, String dialogTitle) {
+		DialogFinder dialogFinder = WindowFinder.findDialog(new DialogTitleMatcher(dialogTitle));
+		DialogFixture dialogFixture = dialogFinder.using(((FestRunner) runner).robot);		
+		dialogFixture.button(new JButtonTextMatcher(buttonText)).click();
+	}
+
+	@Override
+	public void cancel() {
+		// TODO Implement for desktop applications
+		throw new BehaveException(coreMessage.getString("exception-method-not-implemented", "DesktopDialog.cancel()"));
+	}
+
+	@Override
+	public void sendKeys(String keys) {
+		// TODO Implement for desktop applications
+		throw new BehaveException(coreMessage.getString("exception-method-not-implemented", "DesktopDialog.sendKeys(String keys)"));
+	}
+
+	@Override
+	public String getText() {
+		// TODO Implement for desktop applications
+		throw new BehaveException(coreMessage.getString("exception-method-not-implemented", "DesktopDialog.getText()"));
+	}
+	
+	private JButton getDialogButton(java.awt.Dialog dialog) {
+		ArrayList<Component> components = new ArrayList<Component>(); 
+		getDialogComponentes(dialog, components);
+		
+		for (Component component : components) {
+			
+			if (component instanceof JButton) {
+				return (JButton) component;
+			}
+			
+		}
+		
+		return null;
+	}
+	
+	private void getDialogComponentes(Container container, ArrayList<Component> returnComponents) {
+
+		for (Component component :  container.getComponents()) {
+			returnComponents.add(component);			
+			
+			if (component instanceof Container) {
+				getDialogComponentes((Container) component, returnComponents);
+			}
+			
+		}
+		
+	}
+
+	private static class DialogTitleMatcher extends GenericTypeMatcher<java.awt.Dialog> {
+		private final String matchString;
+
+		public DialogTitleMatcher(String s) {
+			super(java.awt.Dialog.class, true);
+			this.matchString = s;
+		}
+
+		@Override
+		protected boolean isMatching(java.awt.Dialog dialog) {
+			
+			if (dialog == null) {
+				return false;
+			}
+			
+			String title = dialog.getTitle();
+			
+			boolean matchTitle = title.equalsIgnoreCase(matchString);
+			boolean isShowing = isShowing(dialog);
+			
+			return (title != null) && matchTitle && isShowing;
+		}
+
+		@RunsInEDT
+		private static boolean isShowing(final java.awt.Dialog dialog) {
+			
+			return execute(new GuiQuery<Boolean>() {
+				
+				@Override
+				protected Boolean executeInEDT() {
+					return dialog.isShowing();
+				}
+				
+			});
+			
+		}
+
+		@Override
+		public String toString() {
+			return concat(DialogTitleMatcher.class.getSimpleName(), "(", quote(matchString), ")");
+		}
+	}
+
+	private static class JButtonTextMatcher extends GenericTypeMatcher<JButton> {
+		private final String matchString;
+
+		public JButtonTextMatcher(String s) {
+			super(JButton.class, true);
+			this.matchString = s;
+		}
+
+		@Override
+		protected boolean isMatching(JButton button) {
+			
+			if (button == null) {
+				return false;
+			}
+			
+			String text = button.getText();
+			
+			boolean matchText = text.equalsIgnoreCase(matchString);
+			boolean isShowing = isShowing(button);
+			
+			return (text != null) && matchText && isShowing;
+		}
+
+		@RunsInEDT
+		private static boolean isShowing(final Component component) {
+			
+			return execute(new GuiQuery<Boolean>() {
+				
+				@Override
+				protected Boolean executeInEDT() {
+					return component.isShowing();
+				}
+				
+			});
+			
+		}
+
+		@Override
+		public String toString() {
+			return concat(JButtonTextMatcher.class.getSimpleName(), "(", quote(matchString), ")");
+		}
+	}
+
+}

--- a/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopScreen.java
+++ b/impl/runner/fest/src/main/java/br/gov/frameworkdemoiselle/behave/runner/fest/ui/DesktopScreen.java
@@ -53,14 +53,20 @@ public class DesktopScreen extends DesktopBase implements Screen {
 		waitText(text, 0L);
 	}
 
-	public void waitText(String text, Long timeout) {		
+	public void waitText(String text, Long timeout) {
 		boolean found = false;
 		long startedTime = GregorianCalendar.getInstance().getTimeInMillis();
 
 		while (true) {
 
-			try {				
-				found = super.runner.getHierarchy().contains("text='" + text + "'");				
+			try {
+				String hierarchy = super.runner.getHierarchy();
+				hierarchy = hierarchy.replaceAll("\n", "");
+				
+				boolean foundText = hierarchy.matches(makePattern("text", text));
+				boolean foundMessage = hierarchy.matches(makePattern("message", text));
+				
+				found = foundText || foundMessage;
 			} catch (BehaveException be) {
 				throw be;
 			} catch (Exception e) {
@@ -79,4 +85,11 @@ public class DesktopScreen extends DesktopBase implements Screen {
 		}
 				
 	}
+	
+	private String makePattern(String field, String text) {
+		String pattern = "(.*?)(" + field + "=')(.*?)(" + text + ")(.*?)";
+		
+		return pattern;
+	}
+	
 }

--- a/impl/runner/fest/src/main/resources/META-INF/services/br.gov.frameworkdemoiselle.behave.runner.ui.Dialog
+++ b/impl/runner/fest/src/main/resources/META-INF/services/br.gov.frameworkdemoiselle.behave.runner.ui.Dialog
@@ -1,0 +1,1 @@
+br.gov.frameworkdemoiselle.behave.runner.fest.ui.DesktopDialog

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebDialog.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebDialog.java
@@ -36,12 +36,17 @@
  */
 package br.gov.frameworkdemoiselle.behave.runner.webdriver.ui;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.WebDriver;
 
+import br.gov.frameworkdemoiselle.behave.config.BehaveConfig;
+import br.gov.frameworkdemoiselle.behave.message.BehaveMessage;
 import br.gov.frameworkdemoiselle.behave.runner.ui.Dialog;
 
 public class WebDialog extends WebBase implements Dialog {
+	
+	protected BehaveMessage coreMessage = new BehaveMessage(BehaveConfig.MESSAGEBUNDLE);
 
 	public void accept() {
 		WebDriver driver = (WebDriver) runner.getDriver();
@@ -64,6 +69,12 @@ public class WebDialog extends WebBase implements Dialog {
 		WebDriver driver = (WebDriver) runner.getDriver();
 		Alert dialog = driver.switchTo().alert();
 		return dialog.getText();
+	}
+
+	@Override
+	public void accept(String buttonText, String dialogTitle) {
+		// TODO Implement for web applications
+		throw new NotImplementedException(coreMessage.getString("exception-method-not-implemented", "WebDialog.accept(String dialogName)"));
 	}
 
 }

--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebDialog.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebDialog.java
@@ -74,7 +74,7 @@ public class WebDialog extends WebBase implements Dialog {
 	@Override
 	public void accept(String buttonText, String dialogTitle) {
 		// TODO Implement for web applications
-		throw new NotImplementedException(coreMessage.getString("exception-method-not-implemented", "WebDialog.accept(String dialogName)"));
+		throw new NotImplementedException(coreMessage.getString("exception-method-not-implemented", "WebDialog.accept(String buttonText, String dialogTitle)"));
 	}
 
 }


### PR DESCRIPTION
As classe _Dialog, DialogSteps, DesktopDialog, WebDialog_ e o arquivo _br.gov.frameworkdemoiselle.behave.runner.ui.Dialog_ foram adicionados/alterados para permitir o tratamento de caixas de diálogo para o Fest.

A classe _DesktopScreen_ foi alterada para melhorar o tratamento da detecção de textos na tela. Agora permite que o texto esteja tanto em um _text=_ ou em um _message=_. Deixando apenas como estava, em um _text=_ estava falhando para algumas situações.