### PR TITLE
Igualado parâmetro de 'WebElement.sendkeys' de 'WebTextField.sendKeys' com 'WebTextField.sendKeysWithTries'.

### DIFF
--- a/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebTextField.java
+++ b/impl/runner/webdriver/src/main/java/br/gov/frameworkdemoiselle/behave/runner/webdriver/ui/WebTextField.java
@@ -61,7 +61,7 @@ public class WebTextField extends WebBase implements TextField {
 		String value = charSequenceToString(keysToSend);
 		
 		//Envia uma sequencia de char
-		getElements().get(0).sendKeys(value);
+		getElements().get(0).sendKeys(getValueToSend(value));
 	}
 
 	/**


### PR DESCRIPTION
Igualado parâmetro de 'WebElement.sendkeys' de 'WebTextField.sendKeys' com 'WebTextField.sendKeysWithTries'.

Isso foi feito porque quando estava somente "getElements().get(0).sendKeys(value)" estava inserindo um tanto de espaço em branco na caixa de texto.